### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -1,5 +1,8 @@
 name: Update Database
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/trfv/shisetsu-viewer/security/code-scanning/15](https://github.com/trfv/shisetsu-viewer/security/code-scanning/15)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the jobs only need to check out code and do not perform any write operations, the minimal permission required is `contents: read`. This can be set at the top level of the workflow file, which will apply to all jobs unless overridden. The change should be made near the top of `.github/workflows/database.yml`, after the `name` and before `on`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
