### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Run Scraper
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/trfv/shisetsu-viewer/security/code-scanning/14](https://github.com/trfv/shisetsu-viewer/security/code-scanning/14)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/scraper.yml`. The best practice is to set the minimal permissions required for the workflow to function. Since most jobs only need to read repository contents, start with `contents: read` at the workflow level. If any job requires additional permissions (e.g., `actions/github-script` may need `actions: read` or `actions: write` depending on the script), you can override or extend the permissions at the job level. In this case, the minimal starting point is to add `permissions: contents: read` at the top level, just below the `name` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
