### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Node CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/trfv/shisetsu-viewer/security/code-scanning/1](https://github.com/trfv/shisetsu-viewer/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow appears to only check out code, set up Node.js, cache dependencies, and run tests/builds (with no steps that require write access to the repository), the minimal permission required is `contents: read`. This should be added at the top level of the workflow file (just after the `name:` line and before `on:`), so it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
