### PR TITLE
fix(viewer): resolve TODO/FIXME comments

### DIFF
--- a/packages/viewer/components/DataTable/DataTable.tsx
+++ b/packages/viewer/components/DataTable/DataTable.tsx
@@ -100,7 +100,7 @@ export const DataTable = <T extends Row>({
           return (
             <div
               className={styles["card"]}
-              key={`${row.id}-${index}`}
+              key={row.id}
               onClick={() => onRowClick?.(rowParams)}
               ref={index === rows.length - 50 ? cardTarget : undefined}
             >
@@ -153,25 +153,29 @@ export const DataTable = <T extends Row>({
             return (
               <TableRow
                 hover={true}
-                key={`${row.id}-${index}`} // FIXME
+                key={row.id}
                 onClick={() => onRowClick?.(rowParams)}
                 ref={index === rows.length - 50 ? target : undefined}
                 style={{ cursor: "pointer" }}
               >
-                {tableCols.map((col) => (
-                  <TableCell
-                    align={col.type === "number" ? "right" : "left"}
-                    key={`${row.id}-${col.field}`}
-                    size="small"
-                    style={{
-                      ...cellStyle(col as Column<unknown>),
-                      borderBottomColor: "var(--color-text-secondary)",
-                    }}
-                    variant="body"
-                  >
-                    {getCellValue(col, row, columns)}
-                  </TableCell>
-                ))}
+                {tableCols.map((col) => {
+                  const value = getCellValue(col, row, columns);
+                  return (
+                    <TableCell
+                      align={col.type === "number" ? "right" : "left"}
+                      key={`${row.id}-${col.field}`}
+                      size="small"
+                      style={{
+                        ...cellStyle(col as Column<unknown>),
+                        borderBottomColor: "var(--color-text-secondary)",
+                      }}
+                      title={value}
+                      variant="body"
+                    >
+                      {value}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
             );
           })}

--- a/packages/viewer/pages/Institution.test.tsx
+++ b/packages/viewer/pages/Institution.test.tsx
@@ -3,7 +3,6 @@ import { http, HttpResponse } from "msw";
 import { worker } from "../test/mocks/browser";
 import { renderWithProviders, screen, waitFor } from "../test/utils/test-utils";
 import { createMockInstitutionNode, createMockInstitutionsConnection } from "../test/mocks/data";
-import { ErrorBoundary } from "../components/utils/ErrorBoundary";
 import InstitutionPage, { COLUMNS } from "./Institution";
 
 const TEST_ENDPOINT = import.meta.env.VITE_GRAPHQL_ENDPOINT;
@@ -289,10 +288,7 @@ describe("Institution Page", () => {
   });
 
   describe("エラー処理", () => {
-    it("クエリエラーが発生した場合、ErrorBoundaryがエラーをキャッチする", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
+    it("クエリエラーが発生した場合、Snackbarでエラーを表示する", async () => {
       worker.use(
         http.post(TEST_ENDPOINT, () => {
           return HttpResponse.json({
@@ -301,25 +297,14 @@ describe("Institution Page", () => {
         })
       );
 
-      renderWithProviders(
-        <ErrorBoundary>
-          <InstitutionPage />
-        </ErrorBoundary>,
-        {
-          initialEntries: ["/institution?m=koutou"],
-        }
-      );
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
-          )
-        ).toBeInTheDocument();
+      renderWithProviders(<InstitutionPage />, {
+        initialEntries: ["/institution?m=koutou"],
       });
 
-      consoleSpy.mockRestore();
-      consoleLogSpy.mockRestore();
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/viewer/pages/Institution.tsx
+++ b/packages/viewer/pages/Institution.tsx
@@ -12,6 +12,7 @@ import { CheckboxGroup } from "../components/CheckboxGroup";
 import { DataTable, type Columns } from "../components/DataTable";
 import { SearchForm } from "../components/SearchForm";
 import { Select, type SelectChangeEvent } from "../components/Select";
+import { Snackbar } from "../components/SnackBar";
 import { Spinner } from "../components/Spinner";
 import { ROUTES } from "../constants/routes";
 import { ArrayParam, StringParam, useQueryParams } from "../hooks/useQueryParams";
@@ -129,11 +130,6 @@ export default () => {
     (d) => d.institutions_connection
   );
 
-  if (error) {
-    // TODO Snackbar を描画する
-    throw new Error(error.message);
-  }
-
   const { municipality, availableInstruments, institutionSizes } = institutionSearchParams;
 
   const handleMunicipalityChange = useCallback(
@@ -243,6 +239,7 @@ export default () => {
           />
         )}
       </div>
+      {error && <Snackbar open={true} message={error.message} />}
     </main>
   );
 };

--- a/packages/viewer/pages/Reservation.test.tsx
+++ b/packages/viewer/pages/Reservation.test.tsx
@@ -6,8 +6,6 @@ import {
   createMockSearchableReservationNode,
   createMockSearchableReservationsConnection,
 } from "../test/mocks/data";
-import { ErrorBoundary } from "../components/utils/ErrorBoundary";
-
 vi.mock("../hooks/useIsMobile", () => ({
   useIsMobile: () => false,
 }));
@@ -419,10 +417,7 @@ describe("Reservation Page", () => {
   });
 
   describe("エラー処理", () => {
-    it("クエリエラーが発生した場合、ErrorBoundaryがエラーをキャッチする", async () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-
+    it("クエリエラーが発生した場合、Snackbarでエラーを表示する", async () => {
       worker.use(
         http.post(TEST_ENDPOINT, () => {
           return HttpResponse.json({
@@ -431,25 +426,14 @@ describe("Reservation Page", () => {
         })
       );
 
-      renderWithProviders(
-        <ErrorBoundary>
-          <ReservationPage />
-        </ErrorBoundary>,
-        {
-          initialEntries: ["/reservation?m=koutou"],
-        }
-      );
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
-          )
-        ).toBeInTheDocument();
+      renderWithProviders(<ReservationPage />, {
+        initialEntries: ["/reservation?m=koutou"],
       });
 
-      consoleSpy.mockRestore();
-      consoleLogSpy.mockRestore();
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/viewer/pages/Reservation.tsx
+++ b/packages/viewer/pages/Reservation.tsx
@@ -14,6 +14,7 @@ import { DataTable, type Columns } from "../components/DataTable";
 import { DateRangePicker } from "../components/DateRangePicker";
 import { SearchForm } from "../components/SearchForm";
 import { Select, type SelectChangeEvent } from "../components/Select";
+import { Snackbar } from "../components/SnackBar";
 import { Spinner } from "../components/Spinner";
 import { ROUTES } from "../constants/routes";
 import { ArrayParam, DateParam, StringParam, useQueryParams } from "../hooks/useQueryParams";
@@ -84,7 +85,6 @@ export const COLUMNS: Columns<SearchableReservationNode> = [
       const obj = params.row.reservation?.reservation as Record<string, string>;
       return formatReservationMap(municipality, obj);
     },
-    /** TODO hover したときに中身がすべて表示されるように修正する */
   },
   {
     field: "updated_at",
@@ -139,11 +139,6 @@ export default () => {
     toReservationQueryVariables(resevationSearchParams),
     (d) => d.searchable_reservations_connection
   );
-
-  if (error) {
-    // TODO Snackbar を描画する
-    throw new Error(error.message);
-  }
 
   const { municipality, startDate, endDate, filter, availableInstruments, institutionSizes } =
     resevationSearchParams;
@@ -313,6 +308,7 @@ export default () => {
           />
         )}
       </div>
+      {error && <Snackbar open={true} message={error.message} />}
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- GraphQL エラー時に `throw` → ページ内 `Snackbar` 表示に変更（Reservation, Institution）
- DataTable の行キーを `${row.id}-${index}` → `row.id` に修正（React アンチパターン解消）
- DataTable の TableCell に `title` 属性を追加し、truncate されたテキストをホバーで全文表示可能に

Closes #1502

## Test plan
- [x] `npm run typecheck -w @shisetsu-viewer/viewer` — 型チェック通過
- [x] `npm run test:ci -w @shisetsu-viewer/viewer` — 全 549 テスト通過
- [x] `npm run lint:all` — lint エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)