### PR TITLE
chore(deps): bump @playwright/test to 1.60.0 and unpin Node

### DIFF
--- a/.github/actions/scrape/action.yml
+++ b/.github/actions/scrape/action.yml
@@ -31,9 +31,7 @@ runs:
       with:
         cache: "npm"
         cache-dependency-path: "**/package-lock.json"
-        # Pinned to match the prepare job: Node 24.16.0 hangs `playwright install`
-        # (microsoft/playwright#41000). Unpin once Playwright is bumped to >= 1.60.
-        node-version: "24.15.0"
+        node-version: "24"
     - name: Restore cached node_modules
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -59,9 +59,7 @@ jobs:
         with:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
-          # Pinned: Node 24.16.0 hangs `playwright install` during zip extraction
-          # (microsoft/playwright#41000). Unpin once Playwright is bumped to >= 1.60.
-          node-version: "24.15.0"
+          node-version: "24"
       - name: Cache node_modules
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         id: node-modules-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1266,9 +1266,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1286,9 +1283,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1306,9 +1300,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1326,9 +1317,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1346,9 +1334,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1366,9 +1351,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1386,9 +1368,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1406,9 +1385,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1426,9 +1402,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1452,9 +1425,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1478,9 +1448,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1504,9 +1471,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1530,9 +1494,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1556,9 +1517,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1582,9 +1540,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1608,9 +1563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2665,12 +2617,12 @@
       ]
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2821,9 +2773,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2841,9 +2790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2861,9 +2807,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2881,9 +2824,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2841,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2921,9 +2858,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7479,9 +7413,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7503,9 +7434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7527,9 +7455,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7551,9 +7476,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8656,12 +8578,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8674,9 +8596,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -11051,7 +10973,7 @@
       "name": "@shisetsu-viewer/scraper",
       "version": "1.0.0",
       "dependencies": {
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.60.0",
         "date-fns": "4.1.0"
       }
     },
@@ -11071,7 +10993,7 @@
         "wouter": "3.9.0"
       },
       "devDependencies": {
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.60.0",
         "@swc/core": "1.15.18",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",

--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.60.0",
     "date-fns": "4.1.0"
   },
   "scripts": {

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -12,7 +12,7 @@
     "wouter": "3.9.0"
   },
   "devDependencies": {
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.60.0",
     "@swc/core": "1.15.18",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",


### PR DESCRIPTION
## What

- Bump `@playwright/test` `1.58.2` → `1.60.0` in both `scraper` and `viewer` (kept in sync).
- Revert the temporary `node-version: "24.15.0"` pin back to `"24"` in `scraper.yml` and the `scrape` composite action.

## Why

The scheduled scraper had been timing out (`prepare` job cancelled at 10m) on **every** run since ~2026-05-28. Root cause: **Node 24.16.0 introduced a regression that hangs `playwright install` during zip extraction** after the browser download reaches 100% (download workers die silently, parent waits on stale IPC pipes — [microsoft/playwright#41000](https://github.com/microsoft/playwright/issues/41000)). Because the workflow used `node-version: "24"` (latest 24.x), CI silently picked up 24.16.0 when it released — no code change required to break it.

A prior hotfix pinned Node to `24.15.0` (already on master, stopped the bleeding). **Playwright 1.60.0 vendors the upstream fix**, so this PR upgrades Playwright and removes the pin — the proper long-term fix.

## Verification

Manually dispatched `Run Scraper` on this branch (unpinned Node → 24.16.0, fresh Playwright-cache miss → real download + extract):

- ✅ `prepare` succeeded in **1m0s** (was hanging → 10m timeout / cancelled)
- ✅ `Install Playwright Browsers` completed, browser cache saved

## Review note

Bumping Playwright changes the bundled **Chromium version** (used by the live scrapers and by viewer's vitest browser-mode tests). The minor bump is low-risk for navigation/selectors, but worth a sanity pass of the scraper CI run / viewer tests before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to the latest version 24 for development workflows
  * Upgraded Playwright testing framework from version 1.58.2 to 1.60.0 across development dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->