### PR TITLE
ci(dependabot): unify target branch to default, add cooldown, switch to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,32 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
+      include:
+        - "*"
     groups:
       github-actions:
         patterns:
           - "*"
 
   - package-ecosystem: "npm"
-    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
+      include:
+        - "*"
     groups:
       react:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 5
-      semver-major-days: 14
-      semver-minor-days: 5
-      semver-patch-days: 3
       include:
         - "*"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 5
       semver-major-days: 14
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 5
       semver-major-days: 14


### PR DESCRIPTION
## 概要

Dependabot の設定を改善します。

### 1. `target-branch: develop` を削除（github-actions / npm 両方）

version updates の PR が default ブランチ `master` を対象になります。

- security updates は仕様上 `target-branch` を無視して常に default ブランチ（`master`）へ出るため、これまで version updates（`develop`）と security updates（`master`）が**別ブランチに分かれて**いました。
- 今回 version updates も `master` に寄せることで一本化。`master` で test pass → リリース、という運用に合わせます。

### 2. `cooldown` を追加（github-actions / npm 両方）

リリース直後の不安定バージョンを避けて待機してから PR を作成します。

| 種別 | 待機日数 |
|------|---------|
| major | 14 日 |
| minor | 5 日 |
| patch | 3 日 |
| default | 5 日 |

### 3. `schedule.interval` を `weekly` → `daily` に変更

cooldown で「こなれていないリリース」はガードされるため、チェックは daily に。

- こなれた更新が**遅延なく毎日小さく届く**ようになり、Claude による triage が回しやすくなる狙い。
- 鮮度ガードは cooldown、頻度は daily、という役割分担。

## 備考

- グルーピング・`ignore` 設定は変更なし。
- YAML のみの変更（コード非変更）のため、ローカルでは型チェック/lint-staged をスキップしています（gitleaks は合格）。
- 反映後、既存の `dependabot/npm_and_yarn/develop/...` 向け PR は `develop` ターゲットのまま残るため、クローズして問題ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update checks to run daily instead of weekly for all package types.
  * Added cooldown rules to space out automated update notifications, with distinct cadences for major/minor/patch releases.
  * Preserved existing grouping patterns for automated updates to avoid changing update organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->