### PR TITLE
chore(deps): group dependabot security updates to reduce lockfile conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
         - "*"
     groups:
       github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -26,12 +31,14 @@ updates:
         - "*"
     groups:
       react:
+        applies-to: version-updates
         patterns:
           - "react"
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
       testing:
+        applies-to: version-updates
         patterns:
           - "vitest"
           - "@vitest/*"
@@ -39,6 +46,7 @@ updates:
           - "@playwright/test"
           - "msw"
       build:
+        applies-to: version-updates
         patterns:
           - "vite"
           - "@vitejs/*"
@@ -48,6 +56,7 @@ updates:
           - "@rollup/*"
           - "wrangler"
       linting:
+        applies-to: version-updates
         patterns:
           - "eslint"
           - "eslint-*"
@@ -56,11 +65,13 @@ updates:
           - "prettier"
           - "prettier-*"
       production-dependencies:
+        applies-to: version-updates
         dependency-type: "production"
         exclude-patterns:
           - "react"
           - "react-dom"
       development-dependencies:
+        applies-to: version-updates
         dependency-type: "development"
         exclude-patterns:
           - "vitest"
@@ -81,6 +92,16 @@ updates:
           - "typescript-eslint"
           - "prettier"
           - "prettier-*"
+      security-production:
+        applies-to: security-updates
+        dependency-type: "production"
+        patterns:
+          - "*"
+      security-development:
+        applies-to: security-updates
+        dependency-type: "development"
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "@typescript/native-preview"
       - dependency-name: "@mizchi/lsmcp"


### PR DESCRIPTION
## 背景

dependabot PR が溜まり、共有の root \`package-lock.json\` を奪い合って連鎖的にコンフリクトしていた。原因を調べたところ、既存の \`groups\` がすべて \`applies-to\` 未指定（＝**バージョン更新にしか効かない**）で、**セキュリティ更新（advisory 起因）がグループ対象外**になっていた。そのため security update が 1 パッケージごとに単独 PR として乱立し、lockfile 競合を増やしていた（例: \`@vitest/browser\` がバージョン更新 PR とセキュリティ更新 PR で二重化）。

## 変更内容

- **セキュリティ更新をグループ化**: \`security-production\` / \`security-development\` を追加。これで npm のセキュリティ更新が prod/dev 各 1 本に集約される。
- **github-actions** にも \`github-actions-security\` グループを追加。
- 既存グループに \`applies-to: version-updates\` を明示してスコープを固定。

挙動は dependabot の次回スケジュール実行時から反映される。

## 補足

- このリポジトリは npm workspaces で lockfile が root に 1 個のため、グループ調整は **PR 本数の削減**には効くが、コンフリクトの根治には green PR を滞留させない（auto-merge）運用が別途有効。
- \`directories: [packages/*]\` のような拡張は workspace が root の \`directory: "/"\` で既にカバーされるため**入れていない**（二重処理・エラー回避）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management configuration to better organize and prioritize security updates separately from routine version updates, improving update handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->