### PR TITLE
fix(scraper): repair tokyo-kita room selectors after site change

### DIFF
--- a/packages/scraper/tokyo-kita/index.ts
+++ b/packages/scraper/tokyo-kita/index.ts
@@ -36,12 +36,20 @@ const STATUS_MAP: Record<string, Status> = {
 
 type ExtractOutput = { date: string; header: string[]; rows: string[][] }[];
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function prepare(page: Page, links: string[]): Promise<Page> {
   await page.goto("https://kita-yoyaku.openreaf02.jp/");
   await page.getByRole("link", { name: "空き状況の確認" }).click();
   await page.getByRole("link", { name: "施設で確認" }).click();
-  for (const link of links) {
-    await page.getByRole("link", { name: link, exact: true }).click();
+  for (const [index, link] of links.entries()) {
+    // 末尾要素は室場リンク。サイト側で定員サフィックス（例「（定員90名）」「(定員646名)」）が
+    // 付与されることがあるため前方一致で照合する。施設分類・施設・「次の一覧」は exact のまま。
+    const isRoom = index === links.length - 1;
+    const name = isRoom ? new RegExp("^" + escapeRegExp(link)) : link;
+    await page.getByRole("link", { name, exact: !isRoom }).click();
   }
   while (true) {
     if ((await page.locator("table.calendar a").count()) > 0) {


### PR DESCRIPTION
## 背景

tokyo-kita（北区）の定期スクレイプが `prepare` 段階で構造系失敗（Issue #1546）。北区サイト（OpenReaf）が室場選択リンクに **定員サフィックス**を付与する変更を行い、`prepare()` の `getByRole("link", { name, exact: true })` による完全一致が外れていた。

実 DOM で確認した変化（`getByRole` のアクセシブル名）:

| 室場 | 旧（コード期待） | 新（現サイト） |
|---|---|---|
| 赤羽会館 講堂 | `講堂` | `講堂 (定員646名)`（半角括弧） |
| 滝野川会館 小ホール | `小ホール` | `小ホール（定員90名）`（全角括弧） |
| 滝野川会館 B201音楽スタジオ | `B201音楽スタジオ` | `B201音楽スタジオ（定員15名）` |
| 滝野川会館 B202音楽スタジオ | `B202音楽スタジオ` | `B202音楽スタジオ（定員15名）` |

`大ホール （平土間）`/`大ホール （客席）` や北とぴあの各室（既に `（定員N名）` 付きで設定済み）は影響なし。括弧種別が施設ごとに半角/全角と不統一で、定員数も将来変わりうるため、室場名のハードコードし直しではなく照合ロジック側を堅牢化する。

## 変更

`tokyo-kita/index.ts` の `prepare()`:
- 室場リンク（`links` の末尾要素）のみ **前方一致**（`new RegExp("^" + escapeRegExp(link))`）で照合。定員サフィックス・括弧種別に依存しない。
- 施設分類・施設名・「次の一覧」（中間リンク）は従来どおり `exact: true` を維持。

## 検証

決定論ハーネス `tools/repair/verify.ts`（`feat/self-healing-scraper` 由来）で実サイト検証。修正前は4件すべて再現、修正後は全 pass:

- 赤羽会館 講堂: REPAIR_VERIFY_RESULT pass=true (31.0s)
- 滝野川会館 小ホール: REPAIR_VERIFY_RESULT pass=true (30.5s)
- 滝野川会館 B201音楽スタジオ: REPAIR_VERIFY_RESULT pass=true (31.0s)
- 滝野川会館 B202音楽スタジオ: REPAIR_VERIFY_RESULT pass=true (31.0s)

回帰確認: `npx playwright test tokyo-kita --retries=0` で **全13テスト pass (1.9m)**。前方一致化で影響しうる `大ホール` 各室・北とぴあ各室も含め全て成功。

Refs #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced Tokyo Kita location scraper navigation handling to more reliably identify and access room listings. The scraper now properly handles cases where the website appends additional information, such as room capacity, to room name identifiers, improving accuracy when navigating through multi-step location selection processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->