### PR TITLE
fix(scraper): classify ota maintenance-window failures as transient

### DIFF
--- a/packages/scraper/common/classifyFailure.test.ts
+++ b/packages/scraper/common/classifyFailure.test.ts
@@ -32,6 +32,20 @@ test("Turnstile 検知は transient", () => {
   );
 });
 
+test("自治体サイトのメンテナンス窓は transient", () => {
+  assert.equal(
+    classifyFailure(
+      "prepare",
+      new Error("システム休止: site under maintenance window (02:00-05:00 JST)")
+    ),
+    "transient"
+  );
+  assert.equal(
+    classifyFailure("prepare", new Error("受付時間外のためご利用いただけません")),
+    "transient"
+  );
+});
+
 test("要素が見つからない locator タイムアウトは structural", () => {
   const message =
     "locator.click: Timeout 10000ms exceeded.\nCall log: waiting for getByRole('link', { name: '次の一覧' })";

--- a/packages/scraper/common/classifyFailure.ts
+++ b/packages/scraper/common/classifyFailure.ts
@@ -7,6 +7,7 @@ const TRANSIENT_PATTERNS: RegExp[] = [
   /ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN/i,
   /socket hang up/i,
   /page\.goto.*Timeout/i, // ナビゲーションのタイムアウト（通常はネットワーク起因）
+  /システム休止|受付時間外|システムメンテナンス/, // 自治体サイトの定期メンテナンス窓
 ];
 
 // 構造変化のシグネチャ。要素が消えた／移動した時の典型的なメッセージ。

--- a/packages/scraper/tokyo-ota/index.ts
+++ b/packages/scraper/tokyo-ota/index.ts
@@ -39,6 +39,13 @@ export async function prepare(
   roomName: string
 ): Promise<Page> {
   await page.goto(BASE_URL);
+  // サイトのメンテナンス窓（02:00-05:00 JST）にスクレイプが当たると "システム休止"
+  // ページが返り、以降の操作はすべて「ログインせずに〜」リンク不在で失敗する。
+  // ここで明示的に検出し、transient として分類されるメッセージで throw する
+  // （classifyFailure の TRANSIENT_PATTERNS と合わせて構造変化と誤分類されないようにする）。
+  if (await page.getByText("システム休止", { exact: false }).first().isVisible()) {
+    throw new Error("システム休止: site under maintenance window (02:00-05:00 JST)");
+  }
   await page.getByRole("link", { name: "ログインせずに空き状況を検索" }).click();
   await page.getByText("カテゴリで検索").click();
   await page.getByText(category, { exact: true }).click();


### PR DESCRIPTION
## 背景
Issue #1560 で tokyo-ota の 22 室すべてが \"Room not found: <building> <room> in category <category>\" として上がっていた。

DOM スナップショットを確認したところ、**全 22 件のキャプチャが同一の「システム休止」ページ**:

> 次の時間帯は、受付時間外のため、ご利用いただけません。(午前２時～午前５時)

スクレイパーの cron は `0 4,16 * * *` (UTC) = `13:00 / 01:00` (JST) 起動。01:00 JST から長く走った retry が 03:00 JST 前後でサイトのメンテナンス窓 (02:00-05:00 JST) に直撃したため、`page.goto(BASE_URL)` 直後から「ログインせずに〜」リンクが見えず、room の検索ループで「Room not found」になっていた。**構造変化ではない**。

## 変更
1. **`packages/scraper/tokyo-ota/index.ts`** — `prepare()` 内、`page.goto(BASE_URL)` 直後に「システム休止」テキスト表示を検出し、transient と分類されるメッセージで早期 throw。無駄な room 検索ループを回避し、明確なエラーメッセージを残す。

2. **`packages/scraper/common/classifyFailure.ts`** — `TRANSIENT_PATTERNS` に `/システム休止|受付時間外|システムメンテナンス/` を追加。他自治体サイトに似たメンテ窓があっても自動で transient 分類されるように一般化。

3. **`packages/scraper/common/classifyFailure.test.ts`** — メンテ窓検知のテストケース追加。

## 検証
ユニットテスト:

\`\`\`
$ node --test 'common/classifyFailure.test.ts'
✔ 自治体サイトのメンテナンス窓は transient
ℹ tests 10 pass 10 fail 0
\`\`\`

実サイト（メンテ窓外、3:00 JST 以降）で複数施設で pass:

\`\`\`
$ node tools/repair/verify.ts tokyo-ota \"大田区民プラザ リハーサル室\"
1 passed (20.6s)
REPAIR_VERIFY_RESULT {\"municipality\":\"tokyo-ota\",\"facility\":\"大田区民プラザ リハーサル室\",\"roomName\":null,\"pass\":true,\"failures\":[]}

$ node tools/repair/verify.ts tokyo-ota \"嶺町文化センター 第一集会室\"
1 passed (16.5s)
REPAIR_VERIFY_RESULT {\"municipality\":\"tokyo-ota\",\"facility\":\"嶺町文化センター 第一集会室\",\"roomName\":null,\"pass\":true,\"failures\":[]}
\`\`\`

## 補足
この変更はメンテ窓ヒット自体は防がない（サイト側の都合）。狙いは:
- 失敗の **正しい分類**: structural 疑いではなく transient として扱う
- collect_failures CI が tracker Issue にメンテ起因の失敗を上げないようにする
- 修復ループ（人手・AI）がメンテ起因のノイズに時間を割かないようにする

中長期的には cron スケジュールを retry 含めメンテ窓を完全に外せるよう調整するのが望ましい。

Refs #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience when encountering maintenance windows and closed-time messages at Japanese municipal sites, enabling better retry handling during temporary unavailability.

* **Tests**
  * Added test coverage for Japanese maintenance and closed-time error detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->