### PR TITLE
docs(repair): add CI dry-run phase to /repair-scraper

### DIFF
--- a/.claude/commands/repair-scraper.md
+++ b/.claude/commands/repair-scraper.md
@@ -96,6 +96,40 @@ EOF
 
 4. マージは人間が行う（このコマンドはマージしない）。
 
+### フェーズ 4.5: CI 実走確認（PR 作成後・マージ前）
+
+ローカルの `verify.ts` は単発の Playwright テストを 1 シャードで実行するだけで、CI の並列性・GitHub Actions の IP / レイテンシ・retry フェーズの挙動までは再現できない。PR を出した後、**PR ブランチに対して `Run Scraper` workflow を dispatch** し、本番と同じ環境で全シャードを走らせて修正が効くことを確認する。
+
+1. dispatch を投げる:
+
+   ```bash
+   gh workflow run scraper.yml --ref fix/repair-<municipality>-$(date +%Y%m%d) -f municipality=<municipality>
+   ```
+
+   - `--ref` は今回作った修正ブランチ。これにより `workflow_dispatch` の prepare ジョブが PR ブランチをチェックアウトして CI を回す。
+   - `municipality` を絞ると prepare ジョブが `shardTotal=20` で起動して所要時間が短い（`all` 指定時は `100` シャード）。
+
+2. 実行 ID を取得し、進捗を watch:
+
+   ```bash
+   gh run list --workflow=scraper.yml --branch fix/repair-<municipality>-$(date +%Y%m%d) --limit 1 --json databaseId,status,conclusion,url
+   gh run watch <run-id>
+   ```
+
+3. 完了後、失敗ジョブの有無を確認:
+
+   ```bash
+   gh run view <run-id> --json jobs --jq '.jobs[] | select(.conclusion=="failure") | .name'
+   ```
+
+4. 失敗ジョブがあれば、対象施設の `_failures/*.json` をダウンロードして再診断（フェーズ 1 へ戻る）。失敗が無ければ PR 本文に CI 実走結果を追記:
+
+   ```bash
+   gh pr comment <pr-number> --body "CI 実走確認 (Run Scraper workflow #<run-id>) でも全シャード成功: <run-url>"
+   ```
+
+**いつ省略してよいか**: メンテナンス窓ヒットや classifier 修正のような「コード上は構造変化に触れていない／touched files が `index.ts` を含まない」ケースは、PR の主目的が分類ロジックだけなので CI 実走確認は任意。逆に **`<municipality>/index.ts` を編集した修復はすべて CI 実走確認を必須**とする（ローカルで passしても CI で flaky になるパターンが多発するため）。
+
 ### フェーズ 5: エスカレーション（5 回で収束しない／全面リニューアルの場合）
 
 1. PR は作らない。
@@ -113,4 +147,5 @@ EOF
 - セレクタの before/after と原因
 - 検証結果（全施設 pass / 一部エスカレーション）
 - 作成した PR 番号、またはエスカレーション内容
+- CI 実走確認（フェーズ 4.5）の run ID / URL、または省略理由
 - 本コマンドの改善案


### PR DESCRIPTION
## 背景
Issue #1560 対応で、ローカルの \`verify.ts\` は通っても CI の retry フェーズで flaky になるパターン (PR #1561: tokyo-bunkyo の \`waitForURL\` タイムアウト) を観測した。\`verify.ts\` は単発 Playwright を 1 シャードで動かすだけで、CI の並列性・runner のレイテンシ・retry フェーズ挙動を再現できない。

`/repair-scraper` skill にも「PR 作成後にマージ前に CI 実走確認する」手順を残しておきたい。

## 変更
\`.claude/commands/repair-scraper.md\`:

- **フェーズ 4.5: CI 実走確認** を追加。PR ブランチに対して \`gh workflow run scraper.yml --ref <branch> -f municipality=<muni>\` で Run Scraper workflow を dispatch し、本番と同じ環境で全シャードを走らせる手順。失敗時は対象施設の失敗レコードを引き戻してフェーズ 1 へ。
- **省略条件を明記**: \`<municipality>/index.ts\` 非編集系の PR（メンテ窓検知・classifier 修正など）は CI 実走確認任意、\`index.ts\` 編集系はすべて必須。
- 完了報告に CI run ID 記録欄を追加。

## 検証
docs only。次回 \`/repair-scraper\` 実行時に新フェーズを実走して機能確認する想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the repair scraper manual with a new verification phase to confirm CI workflow execution and functionality across all environments.
  * Enhanced the completion report checklist to include CI verification run details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->