### PR TITLE
fix(scraper): run unit tests in single process to avoid IPC deserialize error

### DIFF
--- a/packages/scraper/package.json
+++ b/packages/scraper/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "typecheck": "tsgo",
     "test": "npx playwright test",
-    "test:unit": "node --test 'common/*.test.ts'",
+    "test:unit": "node --test --test-isolation=none 'common/*.test.ts'",
     "scrape": "node --env-file=.env scripts/run.ts",
     "update:reservations": "node --env-file=.env tools/updateReservations.ts",
     "update:institutions": "node --env-file=.env tools/updateInstitutions.ts",


### PR DESCRIPTION
## 背景
Node 26 環境で \`npm run test:unit -w @shisetsu-viewer/scraper\` を回した際に断続的に以下が発生:

\`\`\`
✖ common/runScrapeTest.test.ts (209.771546ms)
  Error: Unable to deserialize cloned data due to invalid or unsupported version.
      at #processRawBuffer (node:internal/test_runner/runner:422:20)
      at FileTest.parseMessage (node:internal/test_runner/runner:358:27)
\`\`\`

Node 24+ の \`node --test\` は既定で \`--test-isolation=process\`（各テストファイルを別プロセスで実行 → IPC で結果回収）。テスト本体は成功している（209ms で実行完了）が、child→parent の V8 シリアライズ層で失敗している。CI は Node 24 で再現していないが、開発者環境（Node 26）で発生する。

## 変更
\`packages/scraper/package.json\`:

\`\`\`diff
- \"test:unit\": \"node --test 'common/*.test.ts'\",
+ \"test:unit\": \"node --test --test-isolation=none 'common/*.test.ts'\",
\`\`\`

\`--test-isolation=none\` で全テストを同一プロセス実行に切り替え、IPC を完全に回避する。

副作用リスク: ファイル間で global / \`process.env\` が共有されるが、既存テストは \`fs.mkdtemp\` で per-test の tmpdir を取り、global state を共有しない独立設計のため、影響は無いと判断。

## 検証
\`\`\`
$ for i in 1 2 3 4 5; do npm run test:unit -w @shisetsu-viewer/scraper 2>&1 | grep 'pass\\|fail'; done
ℹ pass 19  ℹ fail 0
ℹ pass 19  ℹ fail 0
ℹ pass 19  ℹ fail 0
ℹ pass 19  ℹ fail 0
ℹ pass 19  ℹ fail 0
\`\`\`

5 連投で全 pass、deserialize エラーなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test runner configuration for the scraper package unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->