### PR TITLE
feat(scraper): detect partial extraction as structural failure

### DIFF
--- a/packages/scraper/common/classifyFailure.test.ts
+++ b/packages/scraper/common/classifyFailure.test.ts
@@ -38,6 +38,16 @@ test("要素が見つからない locator タイムアウトは structural", () 
   assert.equal(classifyFailure("extract", new Error(message)), "structural");
 });
 
+test("期待日数比チェック未満は structural", () => {
+  assert.equal(
+    classifyFailure(
+      "validate",
+      new Error("partial extraction for 施設A: covered 5/30 expected days (17%, threshold 50%)")
+    ),
+    "structural"
+  );
+});
+
 test("認識できないエラーは unknown", () => {
   assert.equal(classifyFailure("prepare", new Error("something weird happened")), "unknown");
 });

--- a/packages/scraper/common/classifyFailure.ts
+++ b/packages/scraper/common/classifyFailure.ts
@@ -15,6 +15,7 @@ const STRUCTURAL_PATTERNS: RegExp[] = [
   /getByRole|getByText|getByLabel/i,
   /resolved to 0 element/i,
   /strict mode violation/i, // セレクタが複数要素にヒット
+  /partial extraction/i, // runScrapeTest の期待日数比チェックで欠落検出
 ];
 
 export function classifyFailure(

--- a/packages/scraper/common/runScrapeTest.test.ts
+++ b/packages/scraper/common/runScrapeTest.test.ts
@@ -143,6 +143,66 @@ test("検証失敗で step=validate・classification=structural・validationErro
   assert.ok(json.validationErrors.length > 0);
 });
 
+test("expectedDateCount に対し distinct date が閾値未満なら partial extraction として throw", async () => {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "runscrape-"));
+  const closed = { count: 0 };
+  const partialOutput = [
+    {
+      room_name: "ホールA",
+      date: "2026-06-17",
+      reservation: { RESERVATION_DIVISION_MORNING: "RESERVATION_STATUS_VACANT" },
+    },
+    {
+      room_name: "ホールA",
+      date: "2026-06-18",
+      reservation: { RESERVATION_DIVISION_MORNING: "RESERVATION_STATUS_VACANT" },
+    },
+  ] as unknown as TransformOutput;
+  await assert.rejects(
+    runScrapeTest({
+      municipality: "tokyo-test",
+      facility: "施設F",
+      context: {},
+      sourceRef: "tokyo-test/index.ts",
+      page: fakePage(closed),
+      baseDir,
+      expectedDateCount: 30,
+      prepare: async () => fakePage(closed),
+      extract: async () => [1, 2],
+      transform: async () => partialOutput,
+      persist: async () => {},
+    }),
+    /partial extraction.*2\/30/
+  );
+  const json = JSON.parse(
+    await fs.readFile(path.join(baseDir, "tokyo-test", "_failures", "施設F.json"), "utf8")
+  );
+  assert.equal(json.failedStep, "validate");
+  assert.equal(json.classification, "structural");
+});
+
+test("expectedDateCount を満たせば partial extraction にならない", async () => {
+  const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "runscrape-"));
+  const closed = { count: 0 };
+  let persisted = false;
+  await runScrapeTest({
+    municipality: "tokyo-test",
+    facility: "施設G",
+    context: {},
+    sourceRef: "tokyo-test/index.ts",
+    page: fakePage(closed),
+    baseDir,
+    expectedDateCount: 1,
+    prepare: async () => fakePage(closed),
+    extract: async () => [1],
+    transform: async () => validOutput,
+    persist: async () => {
+      persisted = true;
+    },
+  });
+  assert.equal(persisted, true);
+});
+
 test("searchPage === page のとき二重 close しない", async () => {
   const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "runscrape-"));
   const closed = { count: 0 };

--- a/packages/scraper/common/runScrapeTest.ts
+++ b/packages/scraper/common/runScrapeTest.ts
@@ -10,7 +10,7 @@ import { captureFailure, clearFailure } from "./captureFailure.ts";
  * 季節休館などのノイズで誤検出しない最低ラインで、サイト構造変化で半減
  * 以上欠落するケース（次へ進む不能・テーブル消失）はしっかり拾う。
  */
-export const PARTIAL_EXTRACTION_THRESHOLD = 0.5;
+const PARTIAL_EXTRACTION_THRESHOLD = 0.5;
 
 export interface RunScrapeTestOptions<E extends { length: number }> {
   /** 自治体スラッグ（例 "tokyo-arakawa"）。 */

--- a/packages/scraper/common/runScrapeTest.ts
+++ b/packages/scraper/common/runScrapeTest.ts
@@ -4,6 +4,14 @@ import type { FailedStep } from "./failureTypes.ts";
 import { validateTransformOutput } from "./validation.ts";
 import { captureFailure, clearFailure } from "./captureFailure.ts";
 
+/**
+ * partial extraction 検出のしきい値。distinct date / expectedDateCount が
+ * これを下回ると structural として throw する。初期値は緩めの 0.5。
+ * 季節休館などのノイズで誤検出しない最低ラインで、サイト構造変化で半減
+ * 以上欠落するケース（次へ進む不能・テーブル消失）はしっかり拾う。
+ */
+export const PARTIAL_EXTRACTION_THRESHOLD = 0.5;
+
 export interface RunScrapeTestOptions<E extends { length: number }> {
   /** 自治体スラッグ（例 "tokyo-arakawa"）。 */
   municipality: string;
@@ -26,6 +34,13 @@ export interface RunScrapeTestOptions<E extends { length: number }> {
   persist: (transformOutput: TransformOutput) => Promise<void>;
   /** テスト用シーム。capture/clear の baseDir に委譲（既定 "test-results"）。 */
   baseDir?: string;
+  /**
+   * 期待する distinct date 件数。指定時は validate 後に
+   * `distinct(date) / expectedDateCount >= PARTIAL_EXTRACTION_THRESHOLD` を
+   * 検証し、未満なら `partial extraction: ...` で throw（structural 分類）。
+   * 各 scraper の calculateCount() などから渡す。
+   */
+  expectedDateCount?: number;
 }
 
 /**
@@ -59,6 +74,15 @@ export async function runScrapeTest<E extends { length: number }>(
     validationErrors = validateTransformOutput(transformOutput);
     if (validationErrors.length > 0) {
       throw new Error(`validation failed for ${label}: ${validationErrors.join("; ")}`);
+    }
+    if (opts.expectedDateCount !== undefined && opts.expectedDateCount > 0) {
+      const distinctDates = new Set(transformOutput.map((r) => r.date)).size;
+      const ratio = distinctDates / opts.expectedDateCount;
+      if (ratio < PARTIAL_EXTRACTION_THRESHOLD) {
+        throw new Error(
+          `partial extraction for ${label}: covered ${distinctDates}/${opts.expectedDateCount} expected days (${Math.round(ratio * 100)}%, threshold ${Math.round(PARTIAL_EXTRACTION_THRESHOLD * 100)}%)`
+        );
+      }
     }
     console.timeEnd(label);
 


### PR DESCRIPTION
## 背景
`extract` 関数内の典型的な防御パターン:

\`\`\`ts
try {
  // navigate / extract one batch
} catch (e) {
  console.warn(\`Failed to extract data at week \${weekIndex + 1}, saving current output.\`, e);
  break;
}
\`\`\`

は、途中で navigation timeout などを catch しても **output が 0 件にも 70 件にもなり得る**。

| 状態 | 現状の挙動 |
|---|---|
| 0 件 | \`extract returned no rows\` で fail（拾える） |
| 期待の 100% 取れた | pass（正しい） |
| **20-80%** だけ取れた | **silent pass**（構造変化のシグナルが消える） |

Issue #1560 の tokyo-bunkyo はまさにこのパターンで、ローカル verify で内部の \`waitForURL\` タイムアウトが 2 回起きていたが output が非空だったため pass 扱い。サイトが完全に壊れる前段階の劣化を検出できていなかった。

## 変更
1. **\`packages/scraper/common/runScrapeTest.ts\`**
   - \`RunScrapeTestOptions\` に optional な \`expectedDateCount?: number\` を追加
   - 定数 \`PARTIAL_EXTRACTION_THRESHOLD = 0.5\` を export
   - validate 後に \`distinct(date) / expectedDateCount\` を計算し、しきい値未満なら \`partial extraction for <label>: covered X/Y expected days (Z%, threshold W%)\` で throw

2. **\`packages/scraper/common/classifyFailure.ts\`**
   - \`STRUCTURAL_PATTERNS\` に \`/partial extraction/i\` を追加。\`collect_failures\` CI が tracker Issue に自動で上げる既存配管に乗せる

3. **テスト追加** (\`runScrapeTest.test.ts\`, \`classifyFailure.test.ts\`)

## 設計判断
- **municipality-agnostic な指標**: distinct date 数なら scraper の出力スキーマに依らず同じ意味。room や division の組み合わせ数は自治体ごとに違うが「いつ取れたか」は共通。
- **opt-in**: 既存 scraper は \`expectedDateCount\` を渡さなければ無視される。完全に後方互換。
- **しきい値 0.5**: 緩めの初期値。季節休館や祝日連続などのノイズで誤検出しない最低ライン。本物の構造劣化（半減以上）は確実に拾う。運用しながら 0.7 まで引き上げ可能。
- **共通契約は変更しない**: \`ScraperModule\` の \`extract\` 戻り値は変えず、テスト側で opt-in する。

## 検証
\`\`\`
$ npm run test:unit -w @shisetsu-viewer/scraper
ℹ tests 22 pass 22 fail 0
\`\`\`

新規テスト:
- \`expectedDateCount に対し distinct date が閾値未満なら partial extraction として throw\`
- \`expectedDateCount を満たせば partial extraction にならない\`
- \`期待日数比チェック未満は structural\`

## Follow-up
本 PR は infrastructure のみ。pilot として tokyo-bunkyo / tokyo-ota の \`index.test.ts\` に \`expectedDateCount: calculateCount()\` を追加する PR を別で出す（#1561 / #1562 マージ後）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-validation completeness checks for date extraction using `expectedDateCount`, with failures triggered when extracted dates fall below a 50% threshold.
* **Bug Fixes**
  * Improved handling of “partial extraction” error messages by classifying them as structural failures.
* **Tests**
  * Added coverage for `expectedDateCount` scenarios, including both failure (partial extraction) and success paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->