### PR TITLE
fix(scraper): updateReservations が _failures ディレクトリで EISDIR クラッシュする問題を修正

### DIFF
--- a/packages/scraper/tools/updateReservations.ts
+++ b/packages/scraper/tools/updateReservations.ts
@@ -38,7 +38,8 @@ for (const target of targets) {
   const dir = `test-results/${target}`;
   let files: string[] = [];
   try {
-    files = await fs.readdir(dir);
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    files = entries.filter((e) => e.isFile() && e.name.endsWith(".json")).map((e) => e.name);
   } catch {
     console.warn(`Directory ${dir} does not exist.`);
     continue;


### PR DESCRIPTION
## 原因

`captureFailure.ts` はスクレイパーテストが失敗した際に `test-results/<municipality>/_failures/` ディレクトリを作成する。

`updateReservations.ts` は `fs.readdir(dir)` でそのディレクトリの全エントリを取得するが、`.json` ファイルだけでなく `_failures/` ディレクトリも含まれる。その後 `fs.readFile("test-results/<municipality>/_failures", "utf-8")` を呼ぶと `EISDIR: illegal operation on a directory, read` で即クラッシュし、DB への予約データ保存がスキップされていた。

## 症状

2026-06-20〜06-22 の複数の定期 Run Scraper で "Save scraped data" / "Start Scraper" ステップが EISDIR で失敗:
- run 27878808296 / 27912389015 / 27944153948 / 27978683153 (各 Scrape job 内の updateReservations)

失敗例:
```
Error: EISDIR: illegal operation on a directory, read
    at async readFileHandle (node:internal/fs/promises:556:24)
    at async file://.../packages/scraper/tools/updateReservations.ts:48:24
```

## 変更内容

`updateReservations.ts` の `readdir` 呼び出しに `{ withFileTypes: true }` を追加し、ファイルかつ `.json` 拡張子のエントリのみを処理するよう変更。

**Before:**
```typescript
files = await fs.readdir(dir);
```

**After:**
```typescript
const entries = await fs.readdir(dir, { withFileTypes: true });
files = entries.filter((e) => e.isFile() && e.name.endsWith(".json")).map((e) => e.name);
```

## 検証

- テスト失敗時に `_failures/` ディレクトリが存在しても EISDIR エラーが発生しないことをコードレビューで確認
- `collect_failures` ステップ内の同様の `readdir` 処理（`scraper.yml` の GitHub Script）はすでに `withFileTypes: true` + `e.isDirectory()` チェックを行っており、同じ防御パターンを採用している


---
_Generated by [Claude Code](https://claude.ai/code/session_017vJFMAJLkPNe4HmtYUoBHB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file processing logic to ensure only JSON files are correctly read and processed when updating reservations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->