### PR TITLE
fix: accept non-RFC institution IDs in MCP tools; re-enable M2M rotation

### DIFF
--- a/.github/actions/scrape/action.yml
+++ b/.github/actions/scrape/action.yml
@@ -77,7 +77,6 @@ runs:
       env:
         GRAPHQL_ENDPOINT: ${{ env.GRAPHQL_ENDPOINT }}
         M2M_TOKEN: ${{ env.M2M_TOKEN }}
-        HASURA_ADMIN_SECRET: ${{ env.HASURA_ADMIN_SECRET }}
       run: |
         node tools/updateReservations.ts ${{ inputs.municipality }}
     - name: Upload failure records

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -86,6 +86,5 @@ jobs:
         env:
           GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
-          HASURA_ADMIN_SECRET: ${{ secrets.HASURA_ADMIN_SECRET }}
         run: |
           node tools/updateInstitutions.ts ${{ needs.prepare.outputs.municipality }}

--- a/.github/workflows/rotate-m2m-token.yml
+++ b/.github/workflows/rotate-m2m-token.yml
@@ -5,14 +5,19 @@ permissions:
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   # Run 1 hour before each scraper run (scraper runs at 0 4,16 * * *)
-  #   - cron: "0 3,15 * * *"
+  schedule:
+    # Run ~1 hour before each scraper run (scraper runs at 0 4,16 * * *) so the
+    # M2M token (24h TTL) is always fresh. Interim measure until the backend
+    # migration (GitHub OIDC) removes M2M tokens entirely.
+    - cron: "23 3,15 * * *"
 
 jobs:
   rotate:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Fetch M2M token from Auth0
         id: fetch-token
@@ -61,3 +66,12 @@ jobs:
             exit 1
           fi
           echo "M2M_TOKEN last updated: ${UPDATED_AT}"
+
+      - name: File issue on rotation failure
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "${{ github.repository }}" \
+            --title "[rotate-m2m-token] M2M トークンの自動ローテーションが失敗" \
+            --body "定期ローテーションが失敗しました。M2M_TOKEN が失効するとスクレイプの Hasura 認証が失敗し続けます。Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -110,7 +110,6 @@ jobs:
         env:
           GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
-          HASURA_ADMIN_SECRET: ${{ secrets.HASURA_ADMIN_SECRET }}
         with:
           municipality: ${{ needs.prepare.outputs.municipality }}
           shardIndex: ${{ matrix.shardIndex }}
@@ -172,7 +171,6 @@ jobs:
         env:
           GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
-          HASURA_ADMIN_SECRET: ${{ secrets.HASURA_ADMIN_SECRET }}
         with:
           municipality: ${{ needs.prepare.outputs.municipality }}
           shardIndex: ${{ matrix.shardIndex }}

--- a/packages/mcp-server/paramHelpers.ts
+++ b/packages/mcp-server/paramHelpers.ts
@@ -1,4 +1,5 @@
 import { AvailabilityDivision, MUNICIPALITIES } from "@shisetsu-viewer/shared";
+import { z } from "zod";
 
 export const MUNICIPALITY_HELP = Object.values(MUNICIPALITIES)
   .map((config) => `${config.key} (${config.label})`)
@@ -6,6 +7,13 @@ export const MUNICIPALITY_HELP = Object.values(MUNICIPALITIES)
 
 export const INSTITUTION_SIZE_HELP =
   "INSTITUTION_SIZE_LARGE (100人以上), INSTITUTION_SIZE_MEDIUM (50〜99人), INSTITUTION_SIZE_SMALL (50人未満)";
+
+// 施設 ID には RFC 4122 非準拠の UUID が含まれる (version/variant ビットが不正な ID が
+// toshima/edogawa/bunkyo/kita に計 17 件)。z.string().uuid() は RFC 厳格検証でこれらを
+// 弾くため、viewer の isValidUuid と同じ 8-4-4-4-12 の hex 形式のみを検証する。
+export const institutionIdSchema = z
+  .string()
+  .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
 
 export function resolveAvailability(value: boolean | string | undefined): string | undefined {
   if (value === undefined) return undefined;

--- a/packages/mcp-server/tools/getInstitutionDetail.ts
+++ b/packages/mcp-server/tools/getInstitutionDetail.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { graphqlRequest } from "../graphqlClient.ts";
 import { INSTITUTION_DETAIL_FIELDS } from "../fieldDefinitions.ts";
 import { buildFieldSelection } from "../buildFieldSelection.ts";
+import { institutionIdSchema } from "../paramHelpers.ts";
 
 function buildQuery(fieldSelection: string): string {
   return `
@@ -48,7 +49,7 @@ export function registerGetInstitutionDetail(server: McpServer): void {
         openWorldHint: false,
       },
       inputSchema: {
-        id: z.string().uuid().describe("施設のUUID"),
+        id: institutionIdSchema.describe("施設のUUID"),
         fields: z
           .array(z.enum(INSTITUTION_DETAIL_FIELDS))
           .optional()

--- a/packages/mcp-server/tools/getInstitutionReservations.ts
+++ b/packages/mcp-server/tools/getInstitutionReservations.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { graphqlRequest } from "../graphqlClient.ts";
 import { RESERVATION_FIELDS } from "../fieldDefinitions.ts";
 import { buildFieldSelection } from "../buildFieldSelection.ts";
+import { institutionIdSchema } from "../paramHelpers.ts";
 
 function buildQuery(fieldSelection: string): string {
   return `
@@ -60,7 +61,7 @@ export function registerGetInstitutionReservations(server: McpServer): void {
         openWorldHint: false,
       },
       inputSchema: {
-        institutionId: z.string().uuid().describe("施設のUUID"),
+        institutionId: institutionIdSchema.describe("施設のUUID"),
         startDate: z
           .string()
           .regex(/^\d{4}-\d{2}-\d{2}$/)

--- a/packages/mcp-server/tools/upsertReservations.ts
+++ b/packages/mcp-server/tools/upsertReservations.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { graphqlRequest } from "../graphqlClient.ts";
+import { institutionIdSchema } from "../paramHelpers.ts";
 
 const MUTATION = `
 mutation update_reservations($data: [reservations_insert_input!]!) {
@@ -38,7 +39,7 @@ export function registerUpsertReservations(server: McpServer): void {
         data: z
           .array(
             z.object({
-              institution_id: z.string().uuid().describe("施設UUID"),
+              institution_id: institutionIdSchema.describe("施設UUID"),
               date: z
                 .string()
                 .regex(/^\d{4}-\d{2}-\d{2}$/)


### PR DESCRIPTION
再構築計画の **Phase 0 / PR 0-2 (応急処置)**。#1590 とは独立 (master ベース)。

## 変更内容

### 1. mcp-server: 17 施設が MCP ツールで参照不能だったバグ修正
施設 ID には RFC 4122 非準拠の UUID が 17 件ある (toshima 11 / edogawa 3 / bunkyo 2 / kita 1。version/variant ビットが不正)。`z.string().uuid()` は RFC 厳格検証のためこれらを弾き、`get_institution_detail` / `get_institution_reservations` / `upsert_reservations` が Invalid UUID エラーになっていた (実際に MCP 経由で再現確認済み)。viewer の `isValidUuid` と同じ緩い 8-4-4-4-12 hex 検証 (`institutionIdSchema`) に統一。

### 2. M2M トークンローテーションの再有効化 (12 時間ごと)
`rotate-m2m-token.yml` の cron はコメントアウトで無効化されていた。**request.ts は HASURA_ADMIN_SECRET を優先するため、現行スクレイプは実質 admin secret (全権) で動いており、M2M_TOKEN は失効している可能性が高い**。
- cron `23 3,15 * * *` (スクレイプ約 1 時間前、Auth0 トークン TTL 24h に対応する元設計の周期) で再有効化
- 失敗時に Issue を自動起票 (トークン失効の静かな死を防ぐ)

### 3. HASURA_ADMIN_SECRET (全権) を CI から除去
scraper.yml / database.yml / scrape action の env から除去し、M2M Bearer (最小権限) 経路に一本化。

## 検証
- [x] typecheck:all / lint:all / format:check:all 全緑
- [x] `institutionIdSchema`: 非 RFC の実 ID を受理、ゴミ/切り詰め/injection 風文字列を拒否 (node で実行確認)
- [x] rotate-m2m-token.yml の diff は cron 有効化 + job 権限 + 失敗時 Issue の 3 点のみ (他は既存とバイト一致)

## ⚠️ マージ後の手順 (順序重要)
1. **即座に** `gh workflow run rotate-m2m-token.yml` で M2M_TOKEN を更新 (ログの expires_in で TTL も確認)
2. 次の定期スクレイプ 2 回が緑であることを確認 (M2M 経路のみで動く実証)
3. その後に secret 本体を削除 (別途確認します): `HASURA_ADMIN_SECRET`、孤児 secret `SCRIPT_ENDPOINT` (リポジトリ内参照ゼロ)
4. mcp-server の本番反映: `npm run deploy -w @shisetsu-viewer/mcp-server` (手動。CD は PR 2-1 で導入予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKyexc7Th5DeAZHnDicmDt