### PR TITLE
feat(shared): make municipality registry the single source of truth

### DIFF
--- a/.claude/commands/new-scraper.md
+++ b/.claude/commands/new-scraper.md
@@ -161,8 +161,9 @@ import { defineScraper } from "../common/defineScraper.ts";
 import type { Division, Status } from "../common/types.ts";
 import { openreafHooks, type OpenreafTarget } from "../engines/openreaf.ts";
 
-const DIVISION_MAP: Record<string, Division> = { "": "RESERVATION_DIVISION_INVALID" /* ... */ };
-const STATUS_MAP: Record<string, Status> = { "": "RESERVATION_STATUS_INVALID" /* ... */ };
+// export は必須（common/registryContract.test.ts が registry との整合を検証する）
+export const DIVISION_MAP: Record<string, Division> = { "": "RESERVATION_DIVISION_INVALID" /* ... */ };
+export const STATUS_MAP: Record<string, Status> = { "": "RESERVATION_STATUS_INVALID" /* ... */ };
 
 const targets: OpenreafTarget[] = [
   /* フェーズ1で収集した対象 */
@@ -245,6 +246,8 @@ MUNICIPALITY_<UPPERCASE_SLUG>: {
 
 - `reservationStatus` の値は viewer で表示されるラベル。スクレイパーの STATUS_MAP のキー（生テキスト）ではなく、人間が読める日本語名にする
 - `reservationDivision` も同様。`"9:00-12:00"` のような生テキストではなく `"午前"` のような表示名
+- `feeDivision` のキーは必ず `FeeDivision.*` を使う。`ReservationDivision.*` を流用すると施設 JSON の `FEE_DIVISION_*` 値と食い違い、viewer で料金ラベルが引けなくなる（杉並区で実際に起きた不具合）
+- 追加後は `npm run test:unit -w @shisetsu-viewer/scraper` の registry ドリフト検査が、scraper.yml / database.yml の choice・README の対応地区・施設 JSON の追記漏れを指摘する。全て緑にすること
 - 既存の同じ予約システム（OpenReaf 等）を使う自治体のエントリを参考にする
 - `reservationExcluded: false` にすることで、viewer のフィルターに表示される
 
@@ -272,28 +275,42 @@ for (const target of scraper.targets) {
 
 ### 2.5 （既存の institution データがない場合） institution データの作成
 
-`data/institutions/<slug>.json` を作成。同じディレクトリの既存ファイルを参考に、施設・部屋の情報をjson形式で記述する。
+`data/institutions/<prefecture>-<slug>.json` を作成。**形式は `Institution` レコード（`packages/shared/types.ts`）のフラットな配列**で、1 部屋 = 1 レコードの DB 完成形（ネストした facilities/rooms 形式ではない）。最小の実例は `data/institutions/tokyo-chuo.json`、enum 値の判定基準は `tasks/institution-data-prompt.md` を参照。
 
 ```json
-{
-  "key": "MUNICIPALITY_<UPPERCASE_SLUG>",
-  "slug": "<slug>",
-  "prefecture": "<tokyo|kanagawa|...>",
-  "label": "<日本語表示名>",
-  "facilities": [
-    {
-      "facilityName": "<施設名>",
-      "rooms": [
-        {
-          "roomName": "<部屋名>"
-        }
-        // ...
-      ]
-    }
-    // ...
-  ]
-}
+[
+  {
+    "id": "<uuidgen 等で採番した UUID>",
+    "prefecture": "PREFECTURE_TOKYO",
+    "municipality": "MUNICIPALITY_<UPPERCASE_SLUG>",
+    "building": "<施設名>",
+    "institution": "<部屋名>",
+    "building_kana": "<シセツメイ（カタカナ）>",
+    "institution_kana": "<ヘヤメイ（カタカナ）>",
+    "building_system_name": "<予約システム上の施設名>",
+    "institution_system_name": "<予約システム上の部屋名>",
+    "capacity": null,
+    "area": null,
+    "institution_size": "INSTITUTION_SIZE_UNKNOWN",
+    "fee_divisions": [],
+    "weekday_usage_fee": [],
+    "holiday_usage_fee": [],
+    "address": "",
+    "is_available_strings": "AVAILABILITY_DIVISION_UNKNOWN",
+    "is_available_woodwind": "AVAILABILITY_DIVISION_UNKNOWN",
+    "is_available_brass": "AVAILABILITY_DIVISION_UNKNOWN",
+    "is_available_percussion": "AVAILABILITY_DIVISION_UNKNOWN",
+    "is_equipped_music_stand": "EQUIPMENT_DIVISION_UNKNOWN",
+    "is_equipped_piano": "EQUIPMENT_DIVISION_UNKNOWN",
+    "website_url": "",
+    "layout_image_url": "",
+    "lottery_period": "",
+    "note": ""
+  }
+]
 ```
+
+`building_system_name` + `institution_system_name` はスクレイパー出力と施設レコードを突合するキーなので、予約システム上の表記と正確に一致させること。楽器利用可否はサイトに明示的な記載がある場合のみ設定する（推測禁止）。
 
 ---
 
@@ -311,6 +328,15 @@ npm run typecheck -w @shisetsu-viewer/scraper
 npx prettier --check packages/scraper/<slug>/index.ts packages/scraper/<slug>/index.test.ts
 npx eslint packages/scraper/<slug>/index.ts packages/scraper/<slug>/index.test.ts
 ```
+
+### 2.6 registry 整合検査
+
+```bash
+npm run test:unit -w @shisetsu-viewer/scraper
+```
+
+- `registryContract.test.ts` — DIVISION_MAP / STATUS_MAP（要 `export`）の値域が registry と整合しているか
+- `registryDrift.test.ts` — scraper.yml / database.yml の choice、README の対応地区、施設 JSON の存在。**失敗が新自治体の追記漏れ箇所を教えてくれる**
 
 ### 3.3 単一部屋テスト
 

--- a/.github/actions/scrape/action.yml
+++ b/.github/actions/scrape/action.yml
@@ -52,6 +52,8 @@ runs:
       env:
         # horizon（取得期間）や開始日の計算はサイトと同じ JST で行う
         TZ: Asia/Tokyo
+        # dispatch で自治体を指定した場合は registry の CI 除外（scraperCiExcluded）を解除する
+        SCRAPER_FORCE_INCLUDE: ${{ inputs.municipality }}
       run: |
         if [ "${{ inputs.debug }}" == "true" ]; then
           DEBUG=pw:api npx playwright test ${{ inputs.municipality }} --shard=${{ inputs.shardIndex }}/${{ inputs.shardTotal }}

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -22,6 +22,7 @@ on:
           - tokyo-ota
           - tokyo-suginami
           - tokyo-chuo
+          - tokyo-meguro
           - kanagawa-kawasaki
 
 jobs:

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -19,6 +19,7 @@ on:
           - tokyo-toshima
           - tokyo-ota
           - tokyo-edogawa
+          - tokyo-meguro
           - kanagawa-kawasaki
           - all
   schedule:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://app.shisetsudb.com
 - 豊島区
 - 中央区
 - 文京区
+- 目黒区
 - 川崎市
 
 ## 備考

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -20,7 +20,9 @@ const config: KnipConfig = {
       ],
     },
     "packages/scraper": {
-      entry: ["**/index.test.ts", "scripts/run.ts", "tools/**/*.ts"],
+      // */index.ts: 自治体スクレイパー。registryContract.test.ts が動的 import で
+      // DIVISION_MAP/STATUS_MAP を参照するため (静的解析不能)、entry として扱う
+      entry: ["**/index.test.ts", "*/index.ts", "scripts/run.ts", "tools/**/*.ts"],
       ignoreDependencies: [
         "@shisetsu-viewer/shared", // workspace dependency resolved by npm workspaces
       ],

--- a/packages/scraper/common/registryContract.test.ts
+++ b/packages/scraper/common/registryContract.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getMunicipalityBySlug, getReservationTargets } from "@shisetsu-viewer/shared";
+
+// 各スクレイパーが export する生テキスト → enum 値のマップ。
+// 値域が registry の表示ラベル定義と一致していることが viewer 表示の前提になる。
+interface ScraperModule {
+  scraper?: { municipality?: string };
+  DIVISION_MAP?: Record<string, string>;
+  STATUS_MAP?: Record<string, string>;
+}
+
+const INVALID_VALUES = new Set(["RESERVATION_DIVISION_INVALID", "RESERVATION_STATUS_INVALID"]);
+
+describe("registry contract", () => {
+  for (const target of getReservationTargets()) {
+    it(`${target}: municipality とマップ値域が registry と整合している`, async () => {
+      const mod = (await import(`../${target}/index.ts`)) as ScraperModule;
+      const slug = target.slice(target.indexOf("-") + 1);
+      const config = getMunicipalityBySlug(slug);
+      assert.ok(config, `registry に slug=${slug} の自治体がありません`);
+
+      assert.equal(
+        mod.scraper?.municipality,
+        target,
+        `${target}/index.ts の scraper.municipality がディレクトリ名と一致しません`
+      );
+
+      assert.ok(
+        mod.DIVISION_MAP,
+        `${target}: DIVISION_MAP を export してください（契約テストが参照します）`
+      );
+      assert.ok(
+        mod.STATUS_MAP,
+        `${target}: STATUS_MAP を export してください（契約テストが参照します）`
+      );
+
+      for (const value of Object.values(mod.DIVISION_MAP)) {
+        if (INVALID_VALUES.has(value)) continue;
+        assert.ok(
+          value in config.reservationDivision,
+          `${target}: DIVISION_MAP の値 ${value} が registry の reservationDivision に存在しません（viewer でラベルが引けません）`
+        );
+      }
+      for (const value of Object.values(mod.STATUS_MAP)) {
+        if (INVALID_VALUES.has(value)) continue;
+        assert.ok(
+          value in config.reservationStatus,
+          `${target}: STATUS_MAP の値 ${value} が registry の reservationStatus に存在しません（viewer でラベルが引けません）`
+        );
+      }
+    });
+  }
+});

--- a/packages/scraper/common/registryDrift.test.ts
+++ b/packages/scraper/common/registryDrift.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  MUNICIPALITIES,
+  getAllMunicipalityTargets,
+  getReservationTargets,
+  type MunicipalityConfig,
+} from "@shisetsu-viewer/shared";
+
+// 自治体一覧の単一ソースは shared/registry.ts。
+// YAML / Markdown など TS から直接参照できない消費箇所は、このドリフト検査で一致を強制する。
+
+const scraperRoot = fileURLToPath(new URL("..", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+function extractMunicipalityOptions(workflowPath: string): string[] {
+  const lines = readFileSync(workflowPath, "utf8").split("\n");
+  const muniIdx = lines.findIndex((l) => /^\s+municipality:\s*$/.test(l));
+  assert.ok(muniIdx >= 0, `${workflowPath}: municipality input が見つかりません`);
+
+  let optIdx = -1;
+  for (let i = muniIdx + 1; i <= muniIdx + 6 && i < lines.length; i++) {
+    if (/^\s+options:\s*$/.test(lines[i] ?? "")) {
+      optIdx = i;
+      break;
+    }
+  }
+  assert.ok(optIdx >= 0, `${workflowPath}: municipality input に options がありません`);
+
+  const options: string[] = [];
+  for (let i = optIdx + 1; i < lines.length; i++) {
+    const match = (lines[i] ?? "").match(/^\s+-\s+(\S+)\s*$/);
+    const value = match?.[1];
+    if (value === undefined) break;
+    options.push(value);
+  }
+  return options;
+}
+
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort();
+}
+
+describe("registry drift", () => {
+  it("scraper.yml の choice が getReservationTargets() + all と一致している", () => {
+    const options = extractMunicipalityOptions(join(repoRoot, ".github/workflows/scraper.yml"));
+    assert.deepEqual(sorted(options), sorted([...getReservationTargets(), "all"]));
+  });
+
+  it("database.yml の choice が getAllMunicipalityTargets() + all と一致している", () => {
+    const options = extractMunicipalityOptions(join(repoRoot, ".github/workflows/database.yml"));
+    assert.deepEqual(sorted(options), sorted([...getAllMunicipalityTargets(), "all"]));
+  });
+
+  it("README の対応地区が registry の label 一覧と一致している", () => {
+    const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
+    const section = readme.split("## 対応地区")[1]?.split("\n## ")[0] ?? "";
+    const listed = section
+      .split("\n")
+      .map((line) => line.match(/^-\s+([^（\s]+)/)?.[1])
+      .filter((label): label is string => label !== undefined);
+    const labels = Object.values<MunicipalityConfig>(MUNICIPALITIES).map((m) => m.label);
+    assert.deepEqual(sorted(listed), sorted(labels));
+  });
+
+  it("スクレイパーディレクトリが getReservationTargets() と一致している", () => {
+    const dirs = readdirSync(scraperRoot, { withFileTypes: true })
+      .filter(
+        (entry) => entry.isDirectory() && existsSync(join(scraperRoot, entry.name, "index.test.ts"))
+      )
+      .map((entry) => entry.name);
+    assert.deepEqual(sorted(dirs), sorted(getReservationTargets()));
+  });
+
+  it("全自治体の施設 JSON (data/institutions/<target>.json) が存在している", () => {
+    for (const target of getAllMunicipalityTargets()) {
+      assert.ok(
+        existsSync(join(scraperRoot, "data/institutions", `${target}.json`)),
+        `data/institutions/${target}.json がありません`
+      );
+    }
+  });
+});

--- a/packages/scraper/kanagawa-kawasaki/index.ts
+++ b/packages/scraper/kanagawa-kawasaki/index.ts
@@ -6,7 +6,7 @@ import { getCellValue } from "../common/playwrightUtils.ts";
 import { type RawSlot, rawSlotsToOutput } from "../common/reservation.ts";
 import type { Division, Status } from "../common/types.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
@@ -15,7 +15,7 @@ const DIVISION_MAP: Record<string, Division> = {
   夜間: "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "image/lw_emptybs.gif": "RESERVATION_STATUS_VACANT",
   "image/lw_finishs.gif": "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/playwright.config.ts
+++ b/packages/scraper/playwright.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from "@playwright/test";
+import { MUNICIPALITIES, type MunicipalityConfig } from "@shisetsu-viewer/shared";
 
 const isCI = !!process.env.CI;
+
+// CI 除外の単一ソースは registry の scraperCiExcluded。
+// SCRAPER_FORCE_INCLUDE（カンマ区切りの target 名）で個別解除できる —
+// workflow_dispatch では対象自治体を渡し、除外中でも実サイト検証を可能にする。
+const forceInclude = (process.env["SCRAPER_FORCE_INCLUDE"] ?? "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const ciExcludedTargets = Object.values<MunicipalityConfig>(MUNICIPALITIES)
+  .filter((m) => m.scraperCiExcluded)
+  .map((m) => `${m.prefecture}-${m.slug}`)
+  .filter((target) => !forceInclude.includes(target));
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -39,5 +53,5 @@ export default defineConfig({
     trace: process.env.CI ? "off" : "on-first-retry",
   },
   testMatch: ["**/index.test.ts"],
-  testIgnore: isCI ? ["**/tokyo-sumida/**", "**/tokyo-meguro/**"] : [],
+  testIgnore: isCI ? ciExcludedTargets.map((target) => `**/${target}/**`) : [],
 });

--- a/packages/scraper/tokyo-arakawa/index.ts
+++ b/packages/scraper/tokyo-arakawa/index.ts
@@ -7,7 +7,7 @@ import { getCellValue, selectAllOptions } from "../common/playwrightUtils.ts";
 import { type RawSlot, rawSlotsToOutput } from "../common/reservation.ts";
 import type { Division, Status } from "../common/types.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   "09:00\n～\n12:00": "RESERVATION_DIVISION_MORNING",
   "09:00\n～\n12:30": "RESERVATION_DIVISION_MORNING",
@@ -26,7 +26,7 @@ const DIVISION_MAP: Record<string, Division> = {
   "19:00\n～\n22:00": "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "/stagia/jsp/images_jp/multi_images/timetable-o.gif": "RESERVATION_STATUS_VACANT",
   Ｘ: "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-bunkyo/index.ts
+++ b/packages/scraper/tokyo-bunkyo/index.ts
@@ -5,7 +5,7 @@ import { collectPaginated } from "../common/paginate.ts";
 import { type RawSlot, rawSlotsToOutput } from "../common/reservation.ts";
 import type { Division, Status } from "../common/types.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
@@ -17,7 +17,7 @@ const DIVISION_MAP: Record<string, Division> = {
   "５コマ": "RESERVATION_DIVISION_DIVISION_5",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   circle: "RESERVATION_STATUS_VACANT",
   triangle: "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-chuo/index.ts
+++ b/packages/scraper/tokyo-chuo/index.ts
@@ -2,14 +2,14 @@ import { defineScraper } from "../common/defineScraper.ts";
 import type { Division, Status } from "../common/types.ts";
 import { openreafHooks, type OpenreafTarget } from "../engines/openreaf.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   "9:00-12:00": "RESERVATION_DIVISION_MORNING",
   "13:00-17:00": "RESERVATION_DIVISION_AFTERNOON",
   "18:00-21:00": "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "○": "RESERVATION_STATUS_VACANT",
   "△": "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-edogawa/index.ts
+++ b/packages/scraper/tokyo-edogawa/index.ts
@@ -4,14 +4,14 @@ import { collectPaginated } from "../common/paginate.ts";
 import { type RawSlot, rawSlotsToOutput } from "../common/reservation.ts";
 import type { Division, Status } from "../common/types.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
   夜間: "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   空き: "RESERVATION_STATUS_VACANT",
   一部空き: "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-kita/index.ts
+++ b/packages/scraper/tokyo-kita/index.ts
@@ -2,7 +2,7 @@ import { defineScraper } from "../common/defineScraper.ts";
 import type { Division, Status } from "../common/types.ts";
 import { openreafHooks, type OpenreafTarget } from "../engines/openreaf.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   "9:00-12:00": "RESERVATION_DIVISION_MORNING",
   "13:00-17:00": "RESERVATION_DIVISION_AFTERNOON",
@@ -14,7 +14,7 @@ const DIVISION_MAP: Record<string, Division> = {
   "19:30-21:30": "RESERVATION_DIVISION_DIVISION_5",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "○": "RESERVATION_STATUS_VACANT",
   "△": "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-koutou/index.ts
+++ b/packages/scraper/tokyo-koutou/index.ts
@@ -7,7 +7,7 @@ import { getCellValue } from "../common/playwrightUtils.ts";
 import { type RawSlot, rawSlotsToOutput } from "../common/reservation.ts";
 import type { Division, Status } from "../common/types.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
@@ -20,7 +20,7 @@ const DIVISION_MAP: Record<string, Division> = {
   "⑥": "RESERVATION_DIVISION_EVENING_TWO",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "image/lw_emptybs.gif": "RESERVATION_STATUS_VACANT",
   "image/lw_finishs.gif": "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-meguro/index.ts
+++ b/packages/scraper/tokyo-meguro/index.ts
@@ -2,14 +2,14 @@ import { defineScraper } from "../common/defineScraper.ts";
 import type { Division, Status } from "../common/types.ts";
 import { webrGrandHooks, type WebrGrandTarget } from "../engines/webrGrand.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
   夜間: "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "○": "RESERVATION_STATUS_VACANT",
   "△": "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-ota/index.ts
+++ b/packages/scraper/tokyo-ota/index.ts
@@ -8,7 +8,7 @@ import type { Division, Status } from "../common/types.ts";
 
 const BASE_URL = "https://www.yoyaku.city.ota.tokyo.jp/eshisetsu/menu/Welcome.cgi";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   // 集会室系 (午前/午後/夜間)
   "09:00 - 12:00": "RESERVATION_DIVISION_MORNING",
@@ -22,7 +22,7 @@ const DIVISION_MAP: Record<string, Division> = {
   "19:30 - 21:30": "RESERVATION_DIVISION_EVENING_TWO",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "../img/std/common/icn_scche_ok.png": "RESERVATION_STATUS_VACANT",
   "../img/std/common/icn_scche_noset.png": "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-sumida/index.ts
+++ b/packages/scraper/tokyo-sumida/index.ts
@@ -5,14 +5,14 @@ import { collectPaginated } from "../common/paginate.ts";
 import { type RawSlot, rawSlotsToOutput } from "../common/reservation.ts";
 import type { Division, Status } from "../common/types.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
   夜間: "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   空き: "RESERVATION_STATUS_VACANT",
   一部空き: "RESERVATION_STATUS_STATUS_1",

--- a/packages/scraper/tokyo-toshima/index.ts
+++ b/packages/scraper/tokyo-toshima/index.ts
@@ -2,14 +2,14 @@ import { defineScraper } from "../common/defineScraper.ts";
 import type { Division, Status } from "../common/types.ts";
 import { webrGrandHooks, type WebrGrandTarget } from "../engines/webrGrand.ts";
 
-const DIVISION_MAP: Record<string, Division> = {
+export const DIVISION_MAP: Record<string, Division> = {
   "": "RESERVATION_DIVISION_INVALID",
   午前: "RESERVATION_DIVISION_MORNING",
   午後: "RESERVATION_DIVISION_AFTERNOON",
   夜間: "RESERVATION_DIVISION_EVENING",
 };
 
-const STATUS_MAP: Record<string, Status> = {
+export const STATUS_MAP: Record<string, Status> = {
   "": "RESERVATION_STATUS_INVALID",
   "○": "RESERVATION_STATUS_VACANT",
   "△": "RESERVATION_STATUS_STATUS_1",

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -14,8 +14,8 @@ npm run typecheck -w @shisetsu-viewer/shared           # Type check with tsgo
 
 Uses `as const` objects with dual-export pattern (`export const Foo = { ... } as const` + `export type Foo = ...`) for both runtime values and union types.
 
-- `ReservationStatus` — 21 statuses (VACANT, STATUS_1..STATUS_20)
-- `ReservationDivision` — 32 time divisions (MORNING, AFTERNOON, EVENING, plus numbered)
+- `ReservationStatus` — 22 values (INVALID, VACANT, STATUS_1..STATUS_20)
+- `ReservationDivision` — 40 values (INVALID, morning/afternoon/evening variants, DIVISION_1..DIVISION_30)
 - `FeeDivision` — 22 fee periods
 - `AvailabilityDivision` — AVAILABLE, UNAVAILABLE, UNKNOWN
 - `EquipmentDivision` — EQUIPPED, UNEQUIPPED, UNKNOWN
@@ -26,8 +26,10 @@ Uses `as const` objects with dual-export pattern (`export const Foo = { ... } as
 
 ### Municipality Registry (`registry.ts`)
 
-- `MUNICIPALITIES` — 10 municipality configs with `as const satisfies Record<string, MunicipalityConfig>`
+- `MUNICIPALITIES` — municipality configs (currently 12) with `as const satisfies Record<string, MunicipalityConfig>`
 - Each config: `key`, `slug`, `prefecture`, `label`, `reservationExcluded`, mappings for `reservationStatus`, `reservationDivision`, `feeDivision`
+- Optional metadata: `scraperCiExcluded` (scraper exists but excluded from scheduled CI; consumed by `packages/scraper/playwright.config.ts`), `maintenanceWindowJst` (site maintenance hours `[start, end)` in JST)
+- `feeDivision` keys MUST use `FeeDivision.*` — reusing `ReservationDivision.*` breaks fee label lookup against institution JSON values
 - `getMunicipalityBySlug(slug)`, `getMunicipalityKeyBySlug(slug)`, `getReservationTargets()`, `getAllMunicipalityTargets()`
 - Types: `MunicipalityConfig`, `MunicipalityKey`
 
@@ -39,3 +41,4 @@ Note: the scraper contract (`ScraperDefinition`) lives in `packages/scraper/comm
 2. Required fields: `key` (MUNICIPALITY_UPPERCASE), `slug` (lowercase), `prefecture`, `label` (Japanese display name), `reservationExcluded` (boolean), `reservationStatus`, `reservationDivision`, `feeDivision` mappings
 3. Set `reservationExcluded: true` if no active scraper exists
 4. Run viewer and scraper tests to verify no regressions
+5. Run `npm run test:unit -w @shisetsu-viewer/scraper` — the registry drift checks point out every other place that must be updated (workflow choices, README, institutions JSON)

--- a/packages/shared/registry.ts
+++ b/packages/shared/registry.ts
@@ -5,7 +5,15 @@ export interface MunicipalityConfig {
   readonly slug: string;
   readonly prefecture: string;
   readonly label: string;
+  /** true = スクレイパー自体が存在しない（ビューア専用データのみ） */
   readonly reservationExcluded: boolean;
+  /**
+   * true = スクレイパーは存在するが定期 CI から除外する（workflow_dispatch では
+   * SCRAPER_FORCE_INCLUDE により実行可能）。playwright.config.ts の testIgnore が参照する。
+   */
+  readonly scraperCiExcluded?: boolean;
+  /** サイトのメンテナンス時間帯 [開始時, 終了時)（JST の時、半開区間） */
+  readonly maintenanceWindowJst?: readonly [number, number];
   readonly reservationStatus: Readonly<Record<string, string>>;
   readonly reservationDivision: Readonly<Record<string, string>>;
   readonly feeDivision: Readonly<Record<string, string>>;
@@ -222,6 +230,8 @@ export const MUNICIPALITIES = {
     prefecture: "tokyo",
     label: "墨田区",
     reservationExcluded: false,
+    // 2026-07-10 からサイト構造変化で故障中。userHome エンジン統合（再構築 PR 1-5b）で解除予定
+    scraperCiExcluded: true,
     reservationStatus: {
       [ReservationStatus.VACANT]: "空き",
       [ReservationStatus.STATUS_1]: "一部空き",
@@ -250,6 +260,8 @@ export const MUNICIPALITIES = {
     prefecture: "tokyo",
     label: "大田区",
     reservationExcluded: false,
+    // サイトのメンテナンス時間帯（JST 02:00-05:00）。窓内のスクレイプは transient 扱いにする
+    maintenanceWindowJst: [2, 5],
     reservationStatus: {
       [ReservationStatus.VACANT]: "空き",
       [ReservationStatus.STATUS_1]: "予約済",
@@ -257,6 +269,8 @@ export const MUNICIPALITIES = {
       [ReservationStatus.STATUS_3]: "休館日",
       [ReservationStatus.STATUS_4]: "保守点検",
       [ReservationStatus.STATUS_5]: "利用中止",
+      // STATUS_6 は歴史的経緯による欠番（DB 保存値と scraper 側 STATUS_MAP が STATUS_7 で
+      // 一貫しているため、renumber は保存データの書き換えを伴う。D1 移行時に吸収する）
       [ReservationStatus.STATUS_7]: "利用不可",
     },
     reservationDivision: {
@@ -315,12 +329,13 @@ export const MUNICIPALITIES = {
       [ReservationDivision.DIVISION_11]: "19時-",
       [ReservationDivision.DIVISION_12]: "20時-",
     },
-    // NOTE: Uses ReservationDivision keys for AFTERNOON_ONE/TWO (existing behavior preserved)
+    // data/institutions/tokyo-suginami.json は FEE_DIVISION_* キーを使うため、
+    // ReservationDivision キーの流用（旧実装）では料金ラベルが引けなかった
     feeDivision: {
       [FeeDivision.MORNING]: "午前",
       [FeeDivision.AFTERNOON]: "午後",
-      [ReservationDivision.AFTERNOON_ONE]: "午後1",
-      [ReservationDivision.AFTERNOON_TWO]: "午後2",
+      [FeeDivision.AFTERNOON_ONE]: "午後1",
+      [FeeDivision.AFTERNOON_TWO]: "午後2",
       [FeeDivision.EVENING]: "夜間",
       [FeeDivision.ONE_HOUR]: "1時間",
     },
@@ -391,6 +406,8 @@ export const MUNICIPALITIES = {
     prefecture: "tokyo",
     label: "目黒区",
     reservationExcluded: false,
+    // 定期実行での安定性が未検証（予約データ 0 行）。dispatch 観測後に解除予定（再構築 PR 1-6）
+    scraperCiExcluded: true,
     reservationStatus: {
       [ReservationStatus.VACANT]: "空き",
       [ReservationStatus.STATUS_1]: "一部空き",


### PR DESCRIPTION
再構築計画の **Phase 1 / PR 1-1**。#1590 / #1591 とは独立 (master ベース)。

## 背景

自治体リストが **8 箇所に手書き重複**しドリフトしていた: registry(12・真) / scraper ディレクトリ(11) / scraper.yml choice(10: **meguro 欠落**) / database.yml choice(11: meguro 欠落) / playwright testIgnore / README(11: 目黒欠落) / viewer municipality.ts / registry.test.ts(10: 実行されずどこからも参照なし)。

## 変更内容

### registry をメタデータ付き単一ソースに
- `scraperCiExcluded` (sumida: 2026-07-10 から故障中 / meguro: 定期実行未検証) と `maintenanceWindowJst` (ota: JST 02-05 時) を追加
- **SUGINAMI.feeDivision のキーを `FeeDivision.*` に修正** — 旧実装は `ReservationDivision.*` を流用しており、施設 JSON の `FEE_DIVISION_*` 値と食い違い料金ラベルが引けなかった実バグ
- OTA STATUS_6 欠番に経緯コメント (renumber は D1 移行時に吸収)

### testIgnore の導出と FORCE_INCLUDE
- playwright.config の testIgnore を registry から導出。`SCRAPER_FORCE_INCLUDE` で個別解除でき、scrape action が dispatch の対象自治体を自動注入
- **既存バグ解消**: dispatch で tokyo-sumida を選ぶと testIgnore により 0 テストで全シャード「No tests found」失敗していた。今後は除外自治体も dispatch で実サイト検証できる (meguro 統合 PR 1-6 の前提)

### ドリフトの機械検査 (test:unit レーンで CI 実行)
- `registryContract.test.ts`: 全スクレイパーの DIVISION_MAP/STATUS_MAP (export 化) の値域が registry と整合 — **11/11 pass、既存ドリフトゼロを確認**
- `registryDrift.test.ts`: scraper.yml / database.yml choice・README 対応地区・ディレクトリ・施設 JSON = registry の一致検査

### リスト是正
- scraper.yml choice に tokyo-meguro (11+all)、database.yml に tokyo-meguro (12+all)、README に目黒区
- new-scraper.md の施設 JSON テンプレートを実形式 (`Institution[]` フラット配列) に修正 — **旧テンプレはネスト形式で従うと壊れたファイルを生成**。shared/CLAUDE.md の数値ドリフト (10→12 自治体等) も修正

## 検証
- [x] typecheck / lint (--max-warnings=0 相当) / format / knip 全緑
- [x] unit tests 55 件 (新規 16 件含む) fail 0
- [x] playwright --list 実測: default 237 / CI 197 (sumida+meguro 除外) / CI+FORCE_INCLUDE=meguro 233 / =sumida 201 — 導出と解除が正確に機能
- [x] 挙動不変: cron 対象自治体は従来と同一 (sumida/meguro は引き続き除外)

## 注意
- viewer の `utils/municipality.ts` (手書き 11 キー、meguro 欠落) の registry 導出化は **meguro 統合 (PR 1-6) で実施** — 今変えると viewer に meguro が現れるが予約データが 0 行のため

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKyexc7Th5DeAZHnDicmDt