### PR TITLE
ci(scraper): dynamic shard matrix + move cron off the maintenance window

### DIFF
--- a/.github/actions/scrape/action.yml
+++ b/.github/actions/scrape/action.yml
@@ -31,21 +31,24 @@ runs:
   using: "composite"
   steps:
     - name: Set Node.js
-      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         cache: "npm"
         cache-dependency-path: "**/package-lock.json"
         node-version: "24"
     - name: Restore cached node_modules
-      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: "**/node_modules"
         key: ${{ inputs.nodeModulesCacheKey }}
+        # prepare が seed 済みのはず。キャッシュが消えていたら無意味な失敗ログを出す前に落とす
+        fail-on-cache-miss: true
     - name: Restore Playwright browsers
-      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cache/ms-playwright
         key: ${{ inputs.playwrightCacheKey }}
+        fail-on-cache-miss: true
     - name: Run Playwright tests
       shell: bash
       working-directory: packages/scraper
@@ -83,9 +86,9 @@ runs:
         node tools/updateReservations.ts ${{ inputs.municipality }}
     - name: Upload failure records
       if: ${{ always() }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: failures-${{ inputs.phase }}-${{ inputs.shardIndex }}-${{ inputs.shardTotal }}
+        name: failures-${{ inputs.phase }}-${{ inputs.municipality }}-${{ inputs.shardIndex }}-${{ inputs.shardTotal }}
         path: packages/scraper/test-results/*/_failures/
         if-no-files-found: ignore
         overwrite: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # 複合アクション (.github/actions/scrape) 内の action は "/" では追跡されないため明示する
+    directories:
+      - "/"
+      - "/.github/actions/scrape"
     schedule:
       interval: "daily"
     cooldown:

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -22,31 +22,26 @@ on:
           - tokyo-meguro
           - kanagawa-kawasaki
           - all
+      density:
+        description: "Tests per shard (higher = fewer shards)"
+        required: false
+        default: "5"
+        type: string
   schedule:
-    - cron: "0 4,16 * * *"
+    # JST 17:23 / 05:23 起点。GitHub cron の実測遅延（最大 ~3.7h）を足しても
+    # ota のメンテナンス窓（JST 02:00-05:00）に到達しない時刻に置く。
+    # 分を 23 にするのは毎時 0 分の混雑を避けるため。
+    - cron: "23 8,20 * * *"
 
 jobs:
   prepare:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     outputs:
-      municipality: ${{ steps.set-matrix.outputs.municipality }}
-      shardIndex: ${{ steps.set-matrix.outputs.shardIndex }}
-      shardTotal: ${{ steps.set-matrix.outputs.shardTotal }}
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
       nodeModulesCacheKey: ${{ steps.set-cache-keys.outputs.nodeModulesCacheKey }}
       playwrightCacheKey: ${{ steps.set-cache-keys.outputs.playwrightCacheKey }}
     steps:
-      - name: Set matrix
-        id: set-matrix
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ github.event.inputs.municipality }}" != "all" ]; then
-            echo "municipality=${{ github.event.inputs.municipality }}" >> $GITHUB_OUTPUT
-            echo "shardIndex=[$(seq -s ',' 1 20)]" >> $GITHUB_OUTPUT
-            echo "shardTotal=[20]" >> $GITHUB_OUTPUT
-          else
-            echo "shardIndex=[$(seq -s ',' 1 100)]" >> $GITHUB_OUTPUT
-            echo "shardTotal=[100]" >> $GITHUB_OUTPUT
-          fi
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set cache keys
@@ -91,18 +86,28 @@ jobs:
           done
           echo "playwright install failed after 3 attempts" >&2
           exit 1
+      - name: Set matrix
+        id: set-matrix
+        working-directory: packages/scraper
+        env:
+          # dispatch で自治体を指定した場合は registry の CI 除外を解除して --list に含める
+          SCRAPER_FORCE_INCLUDE: ${{ github.event.inputs.municipality }}
+          CI: "true"
+        run: |
+          MUNICIPALITY="${{ github.event.inputs.municipality }}"
+          DENSITY="${{ github.event.inputs.density || '5' }}"
+          MATRIX=$(node scripts/shardMatrix.ts "${MUNICIPALITY:-all}" --density "${DENSITY}")
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
 
   scrape:
-    name: Scrape (${{ matrix.shardIndex }}, ${{ matrix.shardTotal }})
+    name: Scrape ${{ matrix.municipality }} (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     needs: prepare
     timeout-minutes: 60
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: false
-      matrix:
-        shardIndex: ${{ fromJson(needs.prepare.outputs.shardIndex) }}
-        shardTotal: ${{ fromJson(needs.prepare.outputs.shardTotal) }}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -112,7 +117,7 @@ jobs:
           GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
         with:
-          municipality: ${{ needs.prepare.outputs.municipality }}
+          municipality: ${{ matrix.municipality }}
           shardIndex: ${{ matrix.shardIndex }}
           shardTotal: ${{ matrix.shardTotal }}
           nodeModulesCacheKey: ${{ needs.prepare.outputs.nodeModulesCacheKey }}
@@ -141,10 +146,10 @@ jobs:
               });
               console.log(`Found ${jobs.length} total jobs via pagination.`);
               const failedShards = jobs
-                .filter((job) => job.name.startsWith('Scrape') && job.conclusion === 'failure')
-                .map((job) => job.name.match(/Scrape \((\d+),\s(\d+)\)/).slice(1))
-                .filter((arr) => arr.length === 2)
-                .map((arr) => ({ shardIndex: arr[0], shardTotal: arr[1] }));
+                .filter((job) => job.name.startsWith('Scrape ') && job.conclusion === 'failure')
+                .map((job) => job.name.match(/^Scrape (\S+) \((\d+)\/(\d+)\)$/))
+                .filter((m) => m !== null)
+                .map((m) => ({ municipality: m[1], shardIndex: m[2], shardTotal: m[3] }));
               console.log(`Failed shards: ${JSON.stringify(failedShards)}`);
               core.setOutput('failedShards', JSON.stringify(failedShards));
             } catch (error) {
@@ -153,7 +158,7 @@ jobs:
             }
 
   retry_scrape:
-    name: Retry Scrape (${{ matrix.shardIndex }}, ${{ matrix.shardTotal }})
+    name: Retry Scrape ${{ matrix.municipality }} (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     needs:
       - prepare
       - prepare_retry
@@ -173,7 +178,7 @@ jobs:
           GRAPHQL_ENDPOINT: ${{ secrets.GRAPHQL_ENDPOINT }}
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
         with:
-          municipality: ${{ needs.prepare.outputs.municipality }}
+          municipality: ${{ matrix.municipality }}
           shardIndex: ${{ matrix.shardIndex }}
           shardTotal: ${{ matrix.shardTotal }}
           nodeModulesCacheKey: ${{ needs.prepare.outputs.nodeModulesCacheKey }}

--- a/packages/scraper/common/shardMatrix.test.ts
+++ b/packages/scraper/common/shardMatrix.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildShardMatrix,
+  countTestsByMunicipality,
+  shardMatrixFromListOutput,
+} from "./shardMatrix.ts";
+
+const SAMPLE = `Listing tests:
+  kanagawa-kawasaki/index.test.ts:6:3 › 国際交流センター
+  kanagawa-kawasaki/index.test.ts:6:3 › すくらむ２１
+  tokyo-chuo/index.test.ts:6:3 › アートはるみ 音楽室
+  tokyo-koutou/index.test.ts:6:3 › 総合区民センター 第一和室
+  tokyo-koutou/index.test.ts:6:3 › 総合区民センター 第二和室
+  tokyo-koutou/index.test.ts:6:3 › 東大島文化センター 第一音楽室
+Total: 6 tests in 3 files`;
+
+describe("countTestsByMunicipality", () => {
+  it("自治体別にテスト数を数える", () => {
+    const counts = countTestsByMunicipality(SAMPLE);
+    assert.equal(counts.get("kanagawa-kawasaki"), 2);
+    assert.equal(counts.get("tokyo-chuo"), 1);
+    assert.equal(counts.get("tokyo-koutou"), 3);
+    assert.equal(counts.size, 3);
+  });
+
+  it("Total 行やヘッダを数えない", () => {
+    const counts = countTestsByMunicipality(SAMPLE);
+    assert.equal(
+      [...counts.values()].reduce((a, b) => a + b, 0),
+      6
+    );
+  });
+
+  it("空入力なら空 Map", () => {
+    assert.equal(countTestsByMunicipality("").size, 0);
+  });
+});
+
+describe("buildShardMatrix", () => {
+  it("density で割ってシャード数を決め、自治体名でソートする", () => {
+    const counts = new Map([
+      ["tokyo-koutou", 3],
+      ["kanagawa-kawasaki", 2],
+      ["tokyo-chuo", 1],
+    ]);
+    const matrix = buildShardMatrix(counts, 2);
+    assert.deepEqual(matrix, [
+      { municipality: "kanagawa-kawasaki", shardIndex: 1, shardTotal: 1 },
+      { municipality: "tokyo-chuo", shardIndex: 1, shardTotal: 1 },
+      { municipality: "tokyo-koutou", shardIndex: 1, shardTotal: 2 },
+      { municipality: "tokyo-koutou", shardIndex: 2, shardTotal: 2 },
+    ]);
+  });
+
+  it("テスト 0 件の自治体は matrix に現れない（空シャード排除）", () => {
+    const counts = new Map([
+      ["tokyo-koutou", 5],
+      ["tokyo-sumida", 0],
+    ]);
+    const matrix = buildShardMatrix(counts, 5);
+    assert.deepEqual(
+      matrix.map((e) => e.municipality),
+      ["tokyo-koutou"]
+    );
+  });
+
+  it("density=5 で 50 件なら 10 シャード", () => {
+    const matrix = buildShardMatrix(new Map([["tokyo-koutou", 50]]), 5);
+    assert.equal(matrix.length, 10);
+    assert.ok(matrix.every((e) => e.shardTotal === 10));
+    assert.deepEqual(
+      matrix.map((e) => e.shardIndex),
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    );
+  });
+
+  it("端数は切り上げる（7 件 / density 5 → 2 シャード）", () => {
+    const matrix = buildShardMatrix(new Map([["tokyo-koutou", 7]]), 5);
+    assert.equal(matrix.length, 2);
+  });
+
+  it("不正な density は例外", () => {
+    assert.throws(() => buildShardMatrix(new Map(), 0));
+    assert.throws(() => buildShardMatrix(new Map(), -1));
+    assert.throws(() => buildShardMatrix(new Map(), 1.5));
+  });
+});
+
+describe("shardMatrixFromListOutput", () => {
+  it("--list 出力から end-to-end で matrix を得る", () => {
+    const matrix = shardMatrixFromListOutput(SAMPLE, 2);
+    assert.deepEqual(matrix, [
+      { municipality: "kanagawa-kawasaki", shardIndex: 1, shardTotal: 1 },
+      { municipality: "tokyo-chuo", shardIndex: 1, shardTotal: 1 },
+      { municipality: "tokyo-koutou", shardIndex: 1, shardTotal: 2 },
+      { municipality: "tokyo-koutou", shardIndex: 2, shardTotal: 2 },
+    ]);
+  });
+});

--- a/packages/scraper/common/shardMatrix.ts
+++ b/packages/scraper/common/shardMatrix.ts
@@ -1,0 +1,56 @@
+/**
+ * `playwright test --list --reporter=list` の出力から、自治体ごとのシャード matrix を組み立てる。
+ *
+ * 定期実行は自治体数（11）に対し 100 固定シャードで、大半が空シャードだった
+ * （空でも checkout + cache restore で ~78 秒/シャード のオーバーヘッドを消費）。
+ * テスト数を density で割ってシャード数を決めることで、空シャードを構造的に無くす。
+ * テスト 0 件の自治体（CI 除外中など）は matrix に現れない。
+ */
+
+export interface ShardMatrixEntry {
+  readonly municipality: string;
+  readonly shardIndex: number;
+  readonly shardTotal: number;
+}
+
+/** `--list` 出力のテスト行から自治体別テスト数を数える。 */
+export function countTestsByMunicipality(listOutput: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const line of listOutput.split("\n")) {
+    // 例: "  tokyo-koutou/index.test.ts:6:3 › 総合区民センター 第一和室"
+    const match = line.match(/^\s*(\S+?)\/index\.test\.ts:\d+:\d+\s/);
+    const municipality = match?.[1];
+    if (municipality === undefined) continue;
+    counts.set(municipality, (counts.get(municipality) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * 自治体別テスト数から matrix include 配列を作る。
+ * @param density 1 シャードあたりの目標テスト数
+ */
+export function buildShardMatrix(
+  counts: ReadonlyMap<string, number>,
+  density: number
+): ShardMatrixEntry[] {
+  if (!Number.isInteger(density) || density < 1) {
+    throw new Error(`density must be a positive integer, got: ${density}`);
+  }
+  const entries: ShardMatrixEntry[] = [];
+  // 自治体名でソートし、出力を決定論的にする（run 間で job 名が安定する）
+  for (const municipality of [...counts.keys()].sort()) {
+    const count = counts.get(municipality) ?? 0;
+    if (count <= 0) continue;
+    const shardTotal = Math.ceil(count / density);
+    for (let shardIndex = 1; shardIndex <= shardTotal; shardIndex++) {
+      entries.push({ municipality, shardIndex, shardTotal });
+    }
+  }
+  return entries;
+}
+
+/** `--list` 出力と density から matrix include 配列を得る。 */
+export function shardMatrixFromListOutput(listOutput: string, density: number): ShardMatrixEntry[] {
+  return buildShardMatrix(countTestsByMunicipality(listOutput), density);
+}

--- a/packages/scraper/scripts/shardMatrix.ts
+++ b/packages/scraper/scripts/shardMatrix.ts
@@ -1,0 +1,71 @@
+/**
+ * `playwright test [<municipality>] --list` を実行し、シャード matrix を JSON で出力する。
+ * GitHub Actions の prepare ジョブから呼ばれ、出力を `strategy.matrix.include` に流し込む。
+ *
+ * 使い方:
+ *   node scripts/shardMatrix.ts [<municipality>] [--density N]
+ *   （municipality 省略時は全対象。--density の既定は 5）
+ *
+ * 出力（1 行の JSON）:
+ *   { "include": [ { "municipality": "...", "shardIndex": 1, "shardTotal": 2 }, ... ] }
+ *
+ * テストが 1 件も無い場合は空 include を返さず exit 1 で落とす
+ * （dispatch のタイポや testIgnore の全除外を、無言のスキップにせず気付けるようにする）。
+ */
+import { execFileSync } from "node:child_process";
+import { shardMatrixFromListOutput } from "../common/shardMatrix.ts";
+
+function parseArgs(argv: string[]): { municipality: string; density: number } {
+  let municipality = "";
+  let density = 5;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--density") {
+      density = Number(argv[++i]);
+    } else if (arg && !arg.startsWith("--")) {
+      municipality = arg;
+    }
+  }
+  if (!Number.isInteger(density) || density < 1) {
+    throw new Error(`--density must be a positive integer, got: ${density}`);
+  }
+  return { municipality, density };
+}
+
+function main(): void {
+  const { municipality, density } = parseArgs(process.argv.slice(2));
+
+  const args = ["playwright", "test", "--list", "--reporter=list"];
+  if (municipality && municipality !== "all") {
+    args.push(municipality);
+  }
+
+  // --list は tests があると exit 0、0 件だと非ゼロで終わるため、出力は常に受け取る
+  let listOutput = "";
+  try {
+    listOutput = execFileSync("npx", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+  } catch (error) {
+    const err = error as { stdout?: string };
+    listOutput = err.stdout ?? "";
+  }
+
+  const include = shardMatrixFromListOutput(listOutput, density);
+  if (include.length === 0) {
+    console.error(
+      `No tests found for municipality=${municipality || "all"}. ` +
+        `Check the municipality name and playwright testIgnore (registry scraperCiExcluded).`
+    );
+    process.exit(1);
+  }
+
+  const totalTests = new Set(include.map((e) => e.municipality)).size;
+  console.error(
+    `Sharding ${include.length} shard(s) across ${totalTests} municipalit(ies) at density=${density}`
+  );
+  process.stdout.write(JSON.stringify({ include }));
+}
+
+main();


### PR DESCRIPTION
再構築計画の **Phase 1 / PR 1-2**。

## 背景（実測）

- 定期実行は 11 自治体に対し **100 固定シャード**。100 シャードの実測は合計 440 分/run・**固定オーバーヘッド ~78 秒/シャード**で、空・薄シャードが構造的な無駄だった
- cron `0 4,16` (JST 01/13 時意図) は GitHub cron 遅延 (実測 1.8〜3.7h) で **夜 run が JST 02:49 開始 → ota メンテ窓 (02-05 時) に直撃**し、直近の夜 run が連続 failure（朝 run は成功）

## 変更内容

### 動的シャード
- `common/shardMatrix.ts` (純関数): `playwright test --list` の出力から自治体別テスト数を数え、`ceil(count/density)` でシャード数を決定。**テスト 0 件の自治体は matrix に現れない**（空シャードを構造的に排除）
- `scripts/shardMatrix.ts`: prepare ジョブから呼ぶ CLI。matrix include JSON を出力。テスト 0 件なら **exit 1**（dispatch のタイポ・testIgnore 全除外を無言のスキップにしない）
- **実測: all → 43 シャード**（koutou 10 / edogawa 8 / arakawa 5 / ota 5 / kawasaki 4 / toshima 3 / kita 3 / bunkyo 3 / chuo 2）。density は dispatch input（既定 5、density 10 なら 24 シャード）
- job 名を `Scrape <muni> (i/N)` に。prepare_retry の regex と retry_scrape の matrix を per-municipality 化。失敗アーティファクト名も per-municipality 化（自治体間の i/N 衝突防止）

### cron 移動
- `0 4,16` → `23 8,20`（JST 17:23 / 05:23 起点）。実測遅延 3.7h を足しても **ota メンテ窓に到達しない**（遅延は後ろ方向のみ）。分を 23 にするのは毎時 0 分の混雑回避

### 供給網
- 複合アクション内の action を最新 SHA に統一（setup-node v6.4.0 / cache v6.1.0 / upload-artifact v7.0.1）。cache restore に `fail-on-cache-miss`
- dependabot の github-actions が `/.github/actions/scrape` を追跡するよう `directories` 化

## 検証
- [x] typecheck / lint / format / knip 全緑
- [x] shardMatrix unit test 9 件（端数切り上げ・0 件除外・density 検証・ソート決定論性）
- [x] CLI 実測: all=43 / tokyo-chuo=2 / FORCE_INCLUDE=meguro=8 / density10=24
- [x] YAML 構文検証（scraper.yml / action.yml / dependabot.yml）
- [ ] **マージ後カナリア**（下記、CI 実走が本番検証）

## ⚠️ マージ後のカナリア手順（スクレイプを止めないため厳守）
1. 朝の定期 run 成功直後（JST 昼前）にマージ
2. 即 `gh workflow run scraper.yml -f municipality=all -f density=5` を手動実行
3. 確認: prepare の matrix（43 シャード・自治体名入り job 名）/ 全シャード緑 / prepare_retry の failedShards が `[]` / updateReservations の upsert 件数が直近 schedule と同水準 / collect_failures が Issue を誤作成しない
4. 単一自治体も `-f municipality=tokyo-chuo`（2 シャード）で確認
5. 当日夜の schedule run（新 cron 初回）を観察。失敗時は **revert 一発**で旧ロジックに完全回帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKyexc7Th5DeAZHnDicmDt