### PR TITLE
fix(viewer): enforce rules-of-hooks and fix Detail hooks violation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 *.json
-graphql-client.tsx
 
 /node_modules
 /build

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -6,14 +6,7 @@ import globals from "globals";
 
 export default tseslint.config([
   {
-    ignores: [
-      "**/*.json",
-      "build/**",
-      "coverage/**",
-      "node_modules/**",
-      "public/**",
-      "packages/viewer/api/graphql-client.tsx",
-    ],
+    ignores: ["**/*.json", "build/**", "coverage/**", "node_modules/**", "public/**"],
   },
   js.configs.recommended,
   tseslint.configs.recommended,
@@ -51,8 +44,19 @@ export default tseslint.config([
       "react/display-name": "off",
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
-      "react-hooks/rules-of-hooks": "warn",
-      "react-hooks/exhaustive-deps": "warn",
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "error",
+      // 匿名の default export アロー（`export default () => {}`）は
+      // rules-of-hooks が発火しない（コンポーネント名を認識できない）ため禁止する。
+      // 名前付き const にして `export default Name;` とする。
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ExportDefaultDeclaration > ArrowFunctionExpression",
+          message:
+            "匿名の default export アローは禁止。名前付き const にして `export default Name;` としてください（rules-of-hooks 発火のため）。",
+        },
+      ],
     },
   },
 ]);

--- a/packages/viewer/pages/Detail.tsx
+++ b/packages/viewer/pages/Detail.tsx
@@ -322,17 +322,14 @@ type TabType = "institution" | "reservation";
 
 const today = new Date();
 
-// 外側は id の検証と Redirect のみ。Hooks は一切呼ばないので、
-// 不正な id での早期 return が rules-of-hooks に抵触しない。
 const DetailPage = () => {
-  const { id } = useParams();
+const { id } = useParams();
   if (!id || !isValidUuid(id)) {
     return <Redirect to={ROUTES.top} replace />;
   }
   return <DetailContent id={id} />;
 };
 
-// 検証済みの id を受け取り、全ての Hooks はここで無条件に呼ぶ。
 const DetailContent = ({ id }: { id: string }) => {
   const [tab, setTab] = useState<TabType>("institution");
   const {

--- a/packages/viewer/pages/Detail.tsx
+++ b/packages/viewer/pages/Detail.tsx
@@ -322,8 +322,18 @@ type TabType = "institution" | "reservation";
 
 const today = new Date();
 
-export default () => {
+// 外側は id の検証と Redirect のみ。Hooks は一切呼ばないので、
+// 不正な id での早期 return が rules-of-hooks に抵触しない。
+const DetailPage = () => {
   const { id } = useParams();
+  if (!id || !isValidUuid(id)) {
+    return <Redirect to={ROUTES.top} replace />;
+  }
+  return <DetailContent id={id} />;
+};
+
+// 検証済みの id を受け取り、全ての Hooks はここで無条件に呼ぶ。
+const DetailContent = ({ id }: { id: string }) => {
   const [tab, setTab] = useState<TabType>("institution");
   const {
     userInfo: { anonymous, trial },
@@ -333,10 +343,6 @@ export default () => {
     (_: ChangeEvent<unknown>, newValue: string) => setTab(newValue as TabType),
     []
   );
-
-  if (!id || !isValidUuid(id)) {
-    return <Redirect to={ROUTES.top} replace />;
-  }
 
   const { loading, data, error } = useGraphQLQuery<InstitutionDetailQueryData>(
     INSTITUTION_DETAIL_QUERY,
@@ -383,3 +389,5 @@ export default () => {
     </main>
   );
 };
+
+export default DetailPage;

--- a/packages/viewer/pages/Institution.tsx
+++ b/packages/viewer/pages/Institution.tsx
@@ -97,7 +97,7 @@ export const COLUMNS: Columns<InstitutionNode> = [
   },
 ];
 
-export default () => {
+const InstitutionPage = () => {
   const [pathname, setLocation] = useLocation();
   const search = useSearch();
 
@@ -243,3 +243,5 @@ export default () => {
     </main>
   );
 };
+
+export default InstitutionPage;

--- a/packages/viewer/pages/Reservation.tsx
+++ b/packages/viewer/pages/Reservation.tsx
@@ -94,7 +94,7 @@ export const COLUMNS: Columns<SearchableReservationNode> = [
   },
 ];
 
-export default () => {
+const ReservationPage = () => {
   const [pathname, setLocation] = useLocation();
   const search = useSearch();
 
@@ -312,3 +312,5 @@ export default () => {
     </main>
   );
 };
+
+export default ReservationPage;

--- a/packages/viewer/pages/Top.tsx
+++ b/packages/viewer/pages/Top.tsx
@@ -1,6 +1,6 @@
 import styles from "./Top.module.css";
 
-export default () => {
+const TopPage = () => {
   return (
     <main className={styles["pageBox"]}>
       <div className={styles["contentBox"]}>
@@ -62,3 +62,5 @@ export default () => {
     </main>
   );
 };
+
+export default TopPage;

--- a/packages/viewer/pages/Waiting.tsx
+++ b/packages/viewer/pages/Waiting.tsx
@@ -3,7 +3,9 @@ import { ROUTES } from "../constants/routes";
 import { useAuth0 } from "../contexts/Auth0";
 import { Loading } from "./Loading";
 
-export default () => {
+const WaitingPage = () => {
   const { isLoading } = useAuth0();
   return isLoading ? <Loading /> : <Redirect to={ROUTES.top} />;
 };
+
+export default WaitingPage;

--- a/packages/viewer/vitest.config.ts
+++ b/packages/viewer/vitest.config.ts
@@ -29,12 +29,11 @@ export default defineConfig({
         "test/",
         "*.config.ts",
         "*.config.js",
-        "api/graphql-client.tsx",
         "dist/",
         "coverage/",
         "**/*.d.ts",
         "**/index.ts",
-        "**/main.tsx",
+        "index.tsx",
       ],
       thresholds: {
         branches: 60,


### PR DESCRIPTION
再構築計画の **Phase 2 / PR 2-3**。viewer のみ・独立。

## 背景（実バグ）

`Detail.tsx` は早期 return（不正 UUID → `<Redirect>`）の**後**に `useGraphQLQuery` を呼んでおり **rules-of-hooks 違反**。id の有効/無効がレンダ間で変わると React が「Rendered fewer hooks than expected」で throw する。

**この違反が CI をすり抜けた真因は warn 設定ではなく、全 5 ページが匿名 default export（`export default () => {}`）で、eslint がコンポーネント名を認識できず rules-of-hooks が発火しなかったこと**（A/B 検証で確認済み。名前付きにすると発火するのはこの 1 件のみ）。

## 変更内容

- 5 ページ（Top / Waiting / Institution / Reservation / Detail）を名前付き const + `export default Name` に
- **Detail を分割**: `DetailPage`（id 検証 + Redirect のみ、Hooks なし）→ `DetailContent`（検証済み id を受け取り全 Hooks を無条件に呼ぶ）。Hooks を guard の上に移す案は不正 id で無駄クエリが飛ぶため不採用
- `rules-of-hooks` / `exhaustive-deps` を **error** 化（現存違反はこの 1 件のみ、分割で解消）。匿名 default export アローを `no-restricted-syntax` で禁止し再発防止
- codegen 時代の化石参照を除去: eslint.config.ts / .prettierignore の `graphql-client.tsx`、vitest.config.ts の `graphql-client.tsx` と `**/main.tsx`（実エントリは `index.tsx`）

## 検証
- [x] typecheck / **lint（error 化 rules で違反ゼロ）** / format / knip 全緑
- [x] viewer vitest **549/549 pass**（Detail.test.tsx 含む、分割の回帰なし）
- [x] Detail の挙動不変: 不正 UUID → Top へ redirect、正常 UUID → 詳細表示（Detail.test.tsx がカバー）

## 補足
- ESLint 10 への更新は本 PR に含めない（eslint-plugin-react の peer 未対応 #3977）。別途 dependabot ignore を設定予定（Phase 2 の残タスク）
- TS7 移行（PR 2-2）は `.npmrc min-release-age=3` が TS7 GA（07-08）をまだブロックするため数日延期

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKyexc7Th5DeAZHnDicmDt