### PR TITLE
fix(viewer): PR4-2 useQueryParams を URL 駆動に修正 + module-level new Date() を除去

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # testing
 **/coverage
 **/__screenshots__/
+**/.vitest-attachments/
 
 # production
 **/dist

--- a/packages/viewer/hooks/useQueryParams.test.ts
+++ b/packages/viewer/hooks/useQueryParams.test.ts
@@ -94,18 +94,21 @@ describe("DateParam", () => {
 
 describe("useQueryParams", () => {
   test("all pattern", () => {
-    const { result, rerender } = renderHook(() =>
-      useQueryParams(
-        {
-          a: NumberParam,
-          b: StringParam,
-          c: ArrayParam,
-          d: DateParam,
-        },
-        () => {},
-        "a=12345&b=ABCDE&c=XXX&c=YYY&c=ZZZ&d=2022-02-26",
-        ""
-      )
+    const setLocationMock = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ search }) =>
+        useQueryParams(
+          {
+            a: NumberParam,
+            b: StringParam,
+            c: ArrayParam,
+            d: DateParam,
+          },
+          setLocationMock,
+          search,
+          ""
+        ),
+      { initialProps: { search: "a=12345&b=ABCDE&c=XXX&c=YYY&c=ZZZ&d=2022-02-26" } }
     );
     expect(result.current[0].a).toBe(12345);
     expect(result.current[0].b).toBe("ABCDE");
@@ -119,13 +122,34 @@ describe("useQueryParams", () => {
         c: ["PPP", "QQQ", "RRR"],
         d: new Date("2022-02-27"),
       });
-      rerender(); // TODO なぜこれが必要かを検討する
     });
 
+    // setQueryParams は内部 state を持たず、setLocation で URL 更新を要求する。
+    expect(setLocationMock).toHaveBeenCalledTimes(1);
+    const [to, options] = setLocationMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ replace: true });
+
+    // 要求された URL で再レンダされた（= wouter が URL を更新した）体で復号値を検証する。
+    rerender({ search: (to as string).split("?")[1] ?? "" });
     expect(result.current[0].a).toBe(54321);
     expect(result.current[0].b).toBe("EDCBA");
     expect(result.current[0].c?.sort().toString()).toBe(["PPP", "QQQ", "RRR"].sort().toString());
     expect(result.current[0].d?.toISOString()).toBe(new Date("2022-02-27").toISOString());
+  });
+  test("search prop の変更で復号値が再同期する", () => {
+    // ブラウザの戻る/進むで wouter の useSearch() が新しい値を返す状況の再現。
+    // 内部 state に固定していると search 変更を無視してしまう（このテストが再同期を強制する）。
+    const { result, rerender } = renderHook(
+      ({ search }) => useQueryParams({ a: NumberParam, b: StringParam }, () => {}, search, ""),
+      { initialProps: { search: "a=1&b=first" } }
+    );
+    expect(result.current[0].a).toBe(1);
+    expect(result.current[0].b).toBe("first");
+
+    rerender({ search: "a=2&b=second" });
+
+    expect(result.current[0].a).toBe(2);
+    expect(result.current[0].b).toBe("second");
   });
   test("empty parameters", () => {
     const { result } = renderHook(() =>
@@ -172,7 +196,7 @@ describe("useQueryParams", () => {
 
   test("setQueryParams with array values exercises toQueryParams array branch", () => {
     const setLocationMock = vi.fn();
-    const { result, rerender } = renderHook(() =>
+    const { result } = renderHook(() =>
       useQueryParams(
         {
           tags: ArrayParam,
@@ -189,19 +213,19 @@ describe("useQueryParams", () => {
         tags: ["a", "b", "c"],
         count: 5,
       });
-      rerender();
     });
 
-    expect(setLocationMock).toHaveBeenCalledWith(expect.stringContaining("/test?"), {
-      replace: true,
-    });
-    expect(result.current[0].tags?.sort().toString()).toBe(["a", "b", "c"].sort().toString());
-    expect(result.current[0].count).toBe(5);
+    expect(setLocationMock).toHaveBeenCalledTimes(1);
+    const [to, options] = setLocationMock.mock.calls[0] ?? [];
+    expect(options).toEqual({ replace: true });
+    const params = new URLSearchParams((to as string).split("?")[1]);
+    expect(params.getAll("tags")).toEqual(["a", "b", "c"]);
+    expect(params.get("count")).toBe("5");
   });
 
   test("setQueryParams with null encode result deletes parameter from URL", () => {
     const setLocationMock = vi.fn();
-    const { result, rerender } = renderHook(() =>
+    const { result } = renderHook(() =>
       useQueryParams(
         {
           name: StringParam,
@@ -216,19 +240,13 @@ describe("useQueryParams", () => {
     expect(result.current[0].name).toBe("hello");
     expect(result.current[0].value).toBe("world");
 
-    // Setting a param to null should delete it from URLSearchParams
+    // name を null にすると URL から削除され、value は残る。
     act(() => {
       result.current[1]({
         name: null as unknown as string,
       });
-      rerender();
     });
 
-    // name should be removed, value should remain unchanged
-    expect(result.current[0].name).toBeUndefined();
-    expect(result.current[0].value).toBe("world");
-
-    // setLocation should be called with URL without name param
     expect(setLocationMock).toHaveBeenCalledWith("/test?value=world", { replace: true });
   });
 

--- a/packages/viewer/hooks/useQueryParams.ts
+++ b/packages/viewer/hooks/useQueryParams.ts
@@ -1,5 +1,5 @@
 import { formatISO, isValid } from "date-fns";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 export const NumberParam = {
   encode: (value: number) => (!!value || value === 0 ? value.toString() : null),
@@ -76,18 +76,18 @@ export const useQueryParams = <QPM extends QueryParamsMap>(
   search: string,
   pathname: string
 ): [DecodedValues<QPM>, (args: DecodedValues<QPM>) => void] => {
-  const [qp, setQP] = useState(new URLSearchParams(search));
+  // search（URL のクエリ文字列）を単一ソースとして復号する。
+  // setQueryParams が setLocation で URL を更新すると search が変わり再レンダされるため、
+  // ブラウザの戻る/進む等の外部由来の URL 変更もそのまま反映される。
+  const qp = useMemo(() => new URLSearchParams(search), [search]);
 
   const setQueryParams = useCallback(
     (dv: DecodedValues<QPM>) => {
-      setQP((prev) => {
-        const next = toQueryParams(dv, prev, qpm);
-        const qs = next.toString();
-        setLocation(qs ? `${pathname}?${qs}` : pathname, { replace: true });
-        return next;
-      });
+      const next = toQueryParams(dv, qp, qpm);
+      const qs = next.toString();
+      setLocation(qs ? `${pathname}?${qs}` : pathname, { replace: true });
     },
-    [qpm, setLocation, pathname]
+    [qp, qpm, setLocation, pathname]
   );
 
   return [toDecodedValues(qp, qpm), setQueryParams];

--- a/packages/viewer/pages/Detail.test.tsx
+++ b/packages/viewer/pages/Detail.test.tsx
@@ -9,6 +9,7 @@ import {
   createMockInstitutionReservationsConnection,
 } from "../test/mocks/data";
 import { ErrorBoundary } from "../components/utils/ErrorBoundary";
+import DetailPage from "./Detail";
 
 const TEST_ENDPOINT = import.meta.env.VITE_GRAPHQL_ENDPOINT;
 
@@ -20,15 +21,10 @@ vi.mock("../hooks/useIsMobile", () => ({
 const VALID_UUID = "b3ed861c-c057-4b71-8678-93b7fea06202";
 const FAKE_NOW = new Date("2025-06-15T12:00:00+09:00");
 
-let DetailPage: React.ComponentType;
-
-beforeEach(async () => {
+beforeEach(() => {
   mockIsMobile.value = false;
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.setSystemTime(FAKE_NOW);
-  vi.resetModules();
-  const mod = await import("./Detail");
-  DetailPage = mod.default;
 });
 
 afterEach(() => {
@@ -255,6 +251,44 @@ describe("Detail Page", () => {
         expect(screen.getByText("日付")).toBeInTheDocument();
       });
       expect(screen.getByText("取得日時")).toBeInTheDocument();
+    });
+
+    it("予約クエリの startDate にレンダ時点の本日を渡す", async () => {
+      let capturedStartDate: unknown = null;
+      worker.use(
+        http.post(TEST_ENDPOINT, async ({ request }) => {
+          const body = (await request.json()) as GraphQLBody;
+          const queryName = body.query.trim().split(/[\s(]/)[1];
+          if (queryName === "institutionDetail") {
+            return HttpResponse.json(defaultDetailResponse);
+          }
+          if (queryName === "institutionReservations") {
+            capturedStartDate = body.variables["startDate"];
+            return HttpResponse.json(createMockInstitutionReservationsConnection([]));
+          }
+          return HttpResponse.json({ data: null });
+        })
+      );
+
+      const { user } = renderWithProviders(<DetailPage />, {
+        initialEntries: [`/institution/${VALID_UUID}`],
+        route: "/institution/:id",
+        auth0Config: { userInfo: { anonymous: false, trial: false } },
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("tab", { name: "予約状況" }));
+
+      // module-level `new Date()` だと import 時刻（実時刻）を固定してしまう。
+      // レンダ時評価なら setSystemTime(FAKE_NOW) を読むため 2025-06-15 になる。
+      await waitFor(() => {
+        expect(capturedStartDate).toBe("2025-06-15");
+      });
     });
 
     it("予約データが空の場合、データなしメッセージを表示する", async () => {

--- a/packages/viewer/pages/Detail.tsx
+++ b/packages/viewer/pages/Detail.tsx
@@ -1,5 +1,5 @@
 import { formatISO } from "date-fns";
-import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { Redirect, useParams } from "wouter";
 import {
   INSTITUTION_DETAIL_QUERY,
@@ -186,6 +186,8 @@ const ReservationTab = ({
   const isMobile = useIsMobile();
   const tableTarget = useRef<HTMLTableRowElement | null>(null);
   const cardTarget = useRef<HTMLDivElement | null>(null);
+  // 「今日」はモジュール読み込み時ではなくタブ表示時点で確定させる（長寿命タブでの日付ずれ防止）。
+  const today = useMemo(() => new Date(), []);
 
   const {
     loading,
@@ -319,8 +321,6 @@ const ReservationTab = ({
 };
 
 type TabType = "institution" | "reservation";
-
-const today = new Date();
 
 const DetailPage = () => {
   const { id } = useParams();

--- a/packages/viewer/pages/Reservation.test.tsx
+++ b/packages/viewer/pages/Reservation.test.tsx
@@ -6,6 +6,7 @@ import {
   createMockSearchableReservationNode,
   createMockSearchableReservationsConnection,
 } from "../test/mocks/data";
+import ReservationPage from "./Reservation";
 vi.mock("../hooks/useIsMobile", () => ({
   useIsMobile: () => false,
 }));
@@ -14,14 +15,9 @@ const TEST_ENDPOINT = import.meta.env.VITE_GRAPHQL_ENDPOINT;
 
 const FAKE_NOW = new Date("2025-06-15T12:00:00+09:00");
 
-let ReservationPage: React.ComponentType;
-
-beforeEach(async () => {
+beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.setSystemTime(FAKE_NOW);
-  vi.resetModules();
-  const mod = await import("./Reservation");
-  ReservationPage = mod.default;
 });
 
 afterEach(() => {

--- a/packages/viewer/pages/Reservation.tsx
+++ b/packages/viewer/pages/Reservation.tsx
@@ -42,9 +42,6 @@ import {
 } from "../utils/search";
 import styles from "./Reservation.module.css";
 
-const minDate = new Date();
-const maxDate = addMonths(endOfMonth(new Date()), 6);
-
 export const COLUMNS: Columns<SearchableReservationNode> = [
   {
     field: "building_and_institution",
@@ -98,6 +95,10 @@ const ReservationPage = () => {
   const [pathname, setLocation] = useLocation();
   const search = useSearch();
 
+  // 「今」はモジュール読み込み時ではなくページ表示時点で確定させる（長寿命タブでの日付ずれ防止）。
+  const minDate = useMemo(() => new Date(), []);
+  const maxDate = useMemo(() => addMonths(endOfMonth(new Date()), 6), []);
+
   const [values, setQueryParams] = useQueryParams(
     {
       m: StringParam,
@@ -124,7 +125,7 @@ const ReservationPage = () => {
         minDate,
         maxDate
       ),
-    [values]
+    [values, minDate, maxDate]
   );
 
   const {
@@ -155,7 +156,7 @@ const ReservationPage = () => {
       /* istanbul ignore next -- date is always provided by DatePicker onChange */
       setQueryParams({ df: date, dt: min([maxDate, max([date ?? endDate, endDate])]) });
     },
-    [setQueryParams, endDate]
+    [setQueryParams, endDate, maxDate]
   );
 
   const handleEndDateChange = useCallback(
@@ -163,7 +164,7 @@ const ReservationPage = () => {
       /* istanbul ignore next -- date is always provided by DatePicker onChange */
       setQueryParams({ df: max([minDate, min([date ?? startDate, startDate])]), dt: date });
     },
-    [setQueryParams, startDate]
+    [setQueryParams, startDate, minDate]
   );
 
   const handleFilterChange = useCallback(

--- a/packages/viewer/test/utils/test-utils.tsx
+++ b/packages/viewer/test/utils/test-utils.tsx
@@ -44,7 +44,10 @@ export function renderWithProviders(
   // Use browser's native userEvent
   const user = browserUserEvent;
 
-  const { hook } = memoryLocation({ path: initialEntries[0] ?? "/", static: true });
+  // 非 static: setLocation → useSearch() の伝播を有効にし、URL 駆動のデータフローを忠実に再現する。
+  // wouter の Router は hook.searchHook を自動継承するため、useSearch() は memory-location の
+  // クエリ文字列を読む。
+  const { hook } = memoryLocation({ path: initialEntries[0] ?? "/" });
 
   function Wrapper({ children }: { children: ReactNode }) {
     return (


### PR DESCRIPTION
## 概要

再構築計画（`docs/superpowers/specs/2026-07-11-repository-rebuild-design.md`）の **PR 4-2「残バグ修正」**。viewer 単独・実サイト不要・ローカル検証で閉じる自律作業。

2つの残バグを TDD で修正した。

## 1. `useQueryParams` の URL 再同期バグ

**症状**: `useState(new URLSearchParams(search))` は初回マウント時にしか `search` を読まないため、`search` prop が変わっても（ブラウザの戻る/進む等、外部由来の URL 変更）内部 state が再同期されず、復号値が古いままになる。テストには `rerender(); // TODO なぜこれが必要かを検討する` という不可解なハックが残っていた。

**修正**: 内部 `useState` をやめ、`search` を単一ソースとする `useMemo(() => new URLSearchParams(search), [search])` 導出（制御された/controlled パターン）に変更。`setQueryParams` → `setLocation` → URL 変更 → `search` 変更 → 再レンダ の自然なデータフローで再同期し、ブラウザ履歴バグが消える。

- 失敗テスト「search prop の変更で復号値が再同期する」を先に追加し RED を確認 → 修正で GREEN。
- 既存テストの `rerender()` ハックを除去し、`setLocation` の呼び出し契約（要求される URL）を検証する assertion に置き換え。`all pattern` は「要求 URL を捕捉→その URL を新 search として注入」の往復テストにした。

## 2. module-level `new Date()`

`Reservation.tsx` の `minDate`/`maxDate`、`Detail.tsx`（`ReservationTab`）の `today` を、module-level から `useMemo(() => new Date(), [])` によるコンポーネント/フック内評価へ移動。モジュール読み込み時刻ではなく **ページ表示時点**で「今」を確定させ、長寿命 SPA タブでの日付ずれを防ぐ。`exhaustive-deps`（error 化済み）に合わせ依存配列を更新。

## テストハーネスの忠実化（`renderWithProviders`）

`memoryLocation` から `static: true` を除去。`static: true` は `navigate` を no-op にするため `setLocation` → `useSearch()` の伝播が起きず、旧 `useQueryParams` の内部 state がそれを覆い隠していた。非 static 化で wouter の Router が `hook.searchHook` を自動継承し、`useSearch()` が memory-location のクエリ文字列を読むようになり、**URL 駆動のデータフローを忠実に再現**する。これにより制御化した `useQueryParams` が実アプリと同じ経路で検証される。

## 検証

- `npm run typecheck:all` ✅
- `npm run lint:all`（`--max-warnings=0`）✅
- `npm run format:check:all` ✅
- `npm run knip` ✅
- viewer vitest: **537 passed（54 files）** ✅（既存テストの回帰なし。`static: true` 除去後も全緑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZvZmgqsAGdiketqsY3RpD
