### PR TITLE
fix(viewer): PR4-3a 無限スクロール sentinel の負値バグ修正 + useInfiniteScroll 共通化

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -13,9 +13,6 @@
     }
   },
   "packages/viewer/components/DataTable/DataTable.tsx": {
-    "@eslint-react/naming-convention-ref-name": {
-      "count": 2
-    },
     "@eslint-react/no-array-index-key": {
       "count": 1
     }
@@ -55,9 +52,6 @@
     }
   },
   "packages/viewer/pages/Detail.tsx": {
-    "@eslint-react/naming-convention-ref-name": {
-      "count": 2
-    },
     "@eslint-react/no-array-index-key": {
       "count": 4
     }

--- a/packages/viewer/components/DataTable/DataTable.test.tsx
+++ b/packages/viewer/components/DataTable/DataTable.test.tsx
@@ -235,6 +235,31 @@ describe("DataTable Component", () => {
       expect(fetchMore).toHaveBeenCalled();
     });
 
+    it("行数が50未満でもhasNextPage=trueならfetchMoreが発火する", async () => {
+      // sentinel を `index === rows.length - 50` に置くと、行数<50 で負値になり
+      // どの行にも付かず observer が何も監視しない → fetchMore が発火しないバグ。
+      // Math.max(0, rows.length - 50) にクランプすれば先頭行に付き、少数件でも発火する。
+      const fewRows: TestRow[] = Array.from({ length: 5 }, (_, i) => ({
+        id: String(i),
+        name: `Name${i}`,
+        age: `${i}`,
+        secret: `Secret${i}`,
+        label: "",
+        createdAt: "2025-01-01",
+        updatedAt: "2025-01-01T00:00:00",
+        score: `${i}`,
+      }));
+
+      const fetchMore = vi.fn().mockResolvedValue(undefined);
+      renderWithProviders(
+        <DataTable columns={columns} rows={fewRows} fetchMore={fetchMore} hasNextPage={true} />
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(fetchMore).toHaveBeenCalled();
+    });
+
     it("アンマウント時にIntersectionObserverがクリーンアップされる", async () => {
       const manyRows: TestRow[] = Array.from({ length: 51 }, (_, i) => ({
         id: String(i),

--- a/packages/viewer/components/DataTable/DataTable.tsx
+++ b/packages/viewer/components/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
 import { useIsMobile } from "../../hooks/useIsMobile";
+import { useInfiniteScroll } from "../../hooks/useInfiniteScroll";
 import { formatDate, formatDatetime } from "../../utils/format";
 import { Skeleton } from "../Skeleton";
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "../Table";
@@ -69,29 +69,13 @@ export const DataTable = <T extends Row>({
   hasNextPage,
 }: Props<T>) => {
   const isMobile = useIsMobile();
-  const target = useRef<HTMLTableRowElement | null>(null);
-  const cardTarget = useRef<HTMLDivElement | null>(null);
+  const { sentinelRef, sentinelIndex } = useInfiniteScroll(fetchMore, rows.length);
 
-  useEffect(() => {
-    const element = isMobile ? cardTarget.current : target.current;
-    if (!element) {
-      return;
-    }
-    const observer = new IntersectionObserver(
-      (entries) => entries[0]?.isIntersecting && fetchMore?.()
-    );
-    observer.observe(element);
-    return () => {
-      observer.unobserve(element);
-    };
-  }, [fetchMore, isMobile, rows.length]);
-
-  const tableCols = columns.filter((column) => !column.hide);
-  const cardCols = columns.filter((column) => !column.hide);
+  const visibleCols = columns.filter((column) => !column.hide);
 
   if (isMobile) {
-    const titleCol = cardCols[0];
-    const detailCols = cardCols.slice(1);
+    const titleCol = visibleCols[0];
+    const detailCols = visibleCols.slice(1);
 
     return (
       <div className={styles["cardList"]}>
@@ -102,7 +86,7 @@ export const DataTable = <T extends Row>({
               className={styles["card"]}
               key={row.id}
               onClick={() => onRowClick?.(rowParams)}
-              ref={index === rows.length - 50 ? cardTarget : undefined}
+              ref={index === sentinelIndex ? sentinelRef : undefined}
             >
               {titleCol && (
                 <div className={styles["cardTitle"]}>{getCellValue(titleCol, row, columns)}</div>
@@ -131,7 +115,7 @@ export const DataTable = <T extends Row>({
       <Table stickyHeader={true}>
         <TableHead>
           <TableRow>
-            {tableCols.map((col) => (
+            {visibleCols.map((col) => (
               <TableCell
                 align={col.type === "number" ? "right" : "left"}
                 key={col.field}
@@ -155,10 +139,10 @@ export const DataTable = <T extends Row>({
                 hover={true}
                 key={row.id}
                 onClick={() => onRowClick?.(rowParams)}
-                ref={index === rows.length - 50 ? target : undefined}
+                ref={index === sentinelIndex ? sentinelRef : undefined}
                 style={{ cursor: "pointer" }}
               >
-                {tableCols.map((col) => {
+                {visibleCols.map((col) => {
                   const value = getCellValue(col, row, columns);
                   return (
                     <TableCell
@@ -181,7 +165,7 @@ export const DataTable = <T extends Row>({
           })}
           {hasNextPage && (
             <TableRow>
-              {tableCols.map((_, index) => (
+              {visibleCols.map((_, index) => (
                 <TableCell key={index} size="small">
                   <Skeleton />
                 </TableCell>

--- a/packages/viewer/hooks/useInfiniteScroll.test.ts
+++ b/packages/viewer/hooks/useInfiniteScroll.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useInfiniteScroll } from "./useInfiniteScroll";
+
+describe("useInfiniteScroll", () => {
+  test("行数が50以上なら末尾から50番目に sentinel を置く", () => {
+    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 100));
+    expect(result.current.sentinelIndex).toBe(50);
+  });
+
+  test("行数がちょうど50なら sentinelIndex は 0", () => {
+    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 50));
+    expect(result.current.sentinelIndex).toBe(0);
+  });
+
+  test("行数が50未満でも sentinelIndex は負値にならず 0 にクランプされる", () => {
+    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 5));
+    expect(result.current.sentinelIndex).toBe(0);
+  });
+
+  test("行数が0でも sentinelIndex は 0", () => {
+    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 0));
+    expect(result.current.sentinelIndex).toBe(0);
+  });
+
+  test("sentinelRef はコールバック ref（関数）", () => {
+    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 10));
+    expect(typeof result.current.sentinelRef).toBe("function");
+  });
+});

--- a/packages/viewer/hooks/useInfiniteScroll.ts
+++ b/packages/viewer/hooks/useInfiniteScroll.ts
@@ -1,0 +1,38 @@
+import { useCallback, useRef } from "react";
+
+/** 末尾から何番目の行に sentinel を置くか（可視化で fetchMore を先読みするための余白）。 */
+const SENTINEL_OFFSET = 50;
+
+/**
+ * 無限スクロール用フック。リストの末尾付近に置いた sentinel 要素が可視領域に入ったら
+ * fetchMore を呼ぶ。sentinel は末尾から SENTINEL_OFFSET 番目の行に置くが、行数が
+ * SENTINEL_OFFSET 未満のときは Math.max で先頭行（index 0）にクランプする。これをしないと
+ * `itemCount - SENTINEL_OFFSET` が負値になり sentinel がどの行にも付かず、少数件のときに
+ * fetchMore が永久に発火しない。
+ *
+ * sentinelRef はコールバック ref。sentinel 行が移動すると React が旧要素に null、新要素に
+ * 要素を渡して呼ぶため、observer の付け替え（disconnect → observe）が自然に起きる。
+ */
+export const useInfiniteScroll = (fetchMore: (() => void) | undefined, itemCount: number) => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const sentinelRef = useCallback(
+    (element: Element | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (!element || !fetchMore) {
+        return;
+      }
+      const observer = new IntersectionObserver(
+        (entries) => entries[0]?.isIntersecting && fetchMore()
+      );
+      observer.observe(element);
+      observerRef.current = observer;
+    },
+    [fetchMore]
+  );
+
+  const sentinelIndex = Math.max(0, itemCount - SENTINEL_OFFSET);
+
+  return { sentinelRef, sentinelIndex };
+};

--- a/packages/viewer/pages/Detail.tsx
+++ b/packages/viewer/pages/Detail.tsx
@@ -1,5 +1,5 @@
 import { formatISO } from "date-fns";
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
 import { Redirect, useParams } from "wouter";
 import {
   INSTITUTION_DETAIL_QUERY,
@@ -10,6 +10,7 @@ import {
   type ReservationNode,
 } from "../api/queries";
 import { useGraphQLQuery } from "../hooks/useGraphQLQuery";
+import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
 import { usePaginatedQuery } from "../hooks/usePaginatedQuery";
 import { IconButton } from "../components/IconButton";
 import { Input } from "../components/Input";
@@ -184,8 +185,6 @@ const ReservationTab = ({
   }
 
   const isMobile = useIsMobile();
-  const tableTarget = useRef<HTMLTableRowElement | null>(null);
-  const cardTarget = useRef<HTMLDivElement | null>(null);
   // 「今日」はモジュール読み込み時ではなくタブ表示時点で確定させる（長寿命タブでの日付ずれ防止）。
   const today = useMemo(() => new Date(), []);
 
@@ -201,17 +200,7 @@ const ReservationTab = ({
     (d) => d.reservations_connection
   );
 
-  useEffect(() => {
-    const element = isMobile ? cardTarget.current : tableTarget.current;
-    if (!element) return;
-    const observer = new IntersectionObserver(
-      (entries) => entries[0]?.isIntersecting && fetchMore()
-    );
-    observer.observe(element);
-    return () => {
-      observer.unobserve(element);
-    };
-  }, [fetchMore, isMobile, reservations?.length]);
+  const { sentinelRef, sentinelIndex } = useInfiniteScroll(fetchMore, reservations?.length ?? 0);
 
   if (error) {
     throw new Error(error.message);
@@ -231,7 +220,7 @@ const ReservationTab = ({
             <div
               className={styles["reservationCard"]}
               key={index}
-              ref={index === reservations.length - 50 ? cardTarget : undefined}
+              ref={index === sentinelIndex ? sentinelRef : undefined}
             >
               <div className={styles["reservationCardDate"]}>{formatMonthDate(row.date)}</div>
               <div className={styles["reservationCardDivisions"]}>
@@ -290,7 +279,7 @@ const ReservationTab = ({
                 <TableRow
                   hover={true}
                   key={index}
-                  ref={index === reservations.length - 50 ? tableTarget : undefined}
+                  ref={index === sentinelIndex ? sentinelRef : undefined}
                 >
                   <TableCell className={styles["reservationTableBodyCell"]} size="small">
                     {formatMonthDate(row.date)}


### PR DESCRIPTION
## 概要

再構築計画の **Phase 4-3「構造整理」の一部（4-3a）**。無限スクロールの sentinel バグ修正と、重複していた IntersectionObserver ロジックの共通フック化。master ベース（#1604 マージ済みの master に rebase 済み）。

## バグ: 無限スクロール sentinel の負値インデックス

`DataTable` と `Detail`（予約タブ）は、末尾から50番目の行に sentinel（IntersectionObserver の監視対象）を置いて「近づいたら次ページを先読み」する。しかしその位置を `index === rows.length - 50` で判定していたため、**行数が 50 未満だと `rows.length - 50` が負値**になり、どの行にも sentinel が付かない → observer が何も監視せず、`fetchMore` が永久に発火しない。

`Math.max(0, count - 50)` にクランプし、行数が少ないときは先頭行（index 0）に sentinel を置くことで、少数件でも `fetchMore` が発火するようにした。

## 共通化: `useInfiniteScroll`

同じ observer + sentinel ロジックが DataTable と Detail に重複（2 observer、4 箇所の ref 配置）。`hooks/useInfiniteScroll.ts` に抽出した。

- `sentinelRef` は**コールバック ref**。sentinel 行が移動すると React が旧要素に `null`、新要素に要素を渡して呼ぶため、observer の付け替え（disconnect → observe）が自然に起きる。
- `(element: Element | null) => void` は `<div>`（カード）と `<TableRow>`（テーブル行）双方の ref に代入可能（引数の反変性）なので、旧コードの 2 refs（`HTMLDivElement` / `HTMLTableRowElement`）を 1 本に統合できる。
- `sentinelIndex = Math.max(0, itemCount - 50)` を返す。

## 変更点

- `hooks/useInfiniteScroll.ts`: 新設（+ ユニットテストで clamp 契約を固定）
- `components/DataTable/DataTable.tsx`: フック採用。完全に同一だった `tableCols`/`cardCols` を `visibleCols` に統合
- `pages/Detail.tsx`: フック採用。自前の observer/`useEffect`/2 refs を除去
- `eslint-suppressions.json`: ref 名が `sentinelRef` に統一され `@eslint-react/naming-convention-ref-name` の抑制が不要化 → prune（DataTable 2 + Detail 2）

## TDD

1. `DataTable.test.tsx` に「行数が50未満でも hasNextPage=true なら fetchMore が発火する」を追加 → **RED**（5 行で sentinel index = -45、ref 未配置で observer 未生成）
2. 最小修正（`Math.max(0, rows.length - 50)`）→ **GREEN**
3. `useInfiniteScroll` を抽出し DataTable/Detail を置換（リファクタ、テスト緑維持）
4. フックの `sentinelIndex` クランプをユニットテストで固定

テストは headless chromium の実 IntersectionObserver を使うため、observer + clamp が end-to-end で検証される。

## 検証

- `npm run typecheck:all` ✅
- `npm run lint:all`（`--max-warnings=0`、suppressions 通知も解消）✅
- `npm run format:check:all` ✅
- `npm run knip` ✅
- viewer vitest: **543 passed（55 files）** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZvZmgqsAGdiketqsY3RpD
