### PR TITLE
fix(api): Auth0 issuer/audience を実トークンに合わせる

### DIFF
--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -18,9 +18,11 @@
     },
   ],
   "vars": {
-    "AUTH0_DOMAIN": "trfv.jp.auth0.com",
-    // TODO(PR3-1 Task 3-1-0): VITE_AUTH0_AUDIENCE と同値を確認して記入する
-    "AUTH0_AUDIENCE": "",
+    // Auth0 カスタムドメイン。実トークンの iss / jwks_uri が auth.shisetsudb.com のため、
+    // issuer 検証と JWKS 取得の両方でこの値を使う（trfv.jp.auth0.com だと全トークンが弾かれる）。
+    "AUTH0_DOMAIN": "auth.shisetsudb.com",
+    // access token の aud 配列に含まれる値（末尾スラッシュ付き）。
+    "AUTH0_AUDIENCE": "https://api.shisetsudb.com/",
     "GITHUB_REPOSITORY": "trfv/shisetsu-viewer",
     "OIDC_AUDIENCE": "https://api.shisetsudb.com",
   },


### PR DESCRIPTION
## 概要

PR 3-1 の Go/No-Go 確認（実 Auth0 access token のクレーム検証）で見つかった config バグの修正。

## 発見

実トークンをデコードした結果:
- **`iss` = `https://auth.shisetsudb.com/`**（Auth0 カスタムドメイン。`trfv.jp.auth0.com` ではなかった）。OIDC discovery でも issuer / jwks_uri とも `auth.shisetsudb.com` を確認。
- **`aud`** に `https://api.shisetsudb.com/`（末尾スラッシュ付き）を含む配列。
- role クレームは `https://hasura.io/jwt/claims` の `x-hasura-default-role: user` のみ（カスタム app claims なし）→ `resolveRole` の Hasura namespace フォールバックが正しく機能。

## 修正

`packages/api/wrangler.jsonc`:
- `AUTH0_DOMAIN`: `trfv.jp.auth0.com` → **`auth.shisetsudb.com`**（issuer 検証と JWKS 取得の両方に使うため）
- `AUTH0_AUDIENCE`: `""` → **`https://api.shisetsudb.com/`**

**影響**: 旧値のままデプロイすると全 Auth0 トークンが issuer 不一致で弾かれ、resolveRole が全員 anonymous を返す → 予約データにアクセス不能になるバグだった。Go/No-Go ゲートが本番前に捕捉。

## 検証

- api 68 テスト緑（テストは env 一貫値で署名・検証するため config 値に非依存）/ typecheck 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)