### PR TITLE
fix(scraper): seed.ts が M2M トークンを自動取得

### DIFF
--- a/packages/scraper/tools/backend/seed.ts
+++ b/packages/scraper/tools/backend/seed.ts
@@ -86,6 +86,15 @@ async function seedReservations(targets: string[]): Promise<void> {
 }
 
 const mode = process.argv[2];
+
+// institutions 以外は Hasura を読むため M2M トークンが要る。run.ts と同様に、
+// M2M_TOKEN も HASURA_ADMIN_SECRET も無ければ Auth0 Client Credentials で自動取得する。
+if (mode !== "institutions" && !process.env.M2M_TOKEN && !process.env["HASURA_ADMIN_SECRET"]) {
+  const { fetchM2MToken } = await import("../m2mAuth.ts");
+  process.env.M2M_TOKEN = await fetchM2MToken();
+  console.log("M2M_TOKEN fetched from Auth0.");
+}
+
 switch (mode) {
   case "institutions":
     await seedInstitutions();


### PR DESCRIPTION
## 概要

`seed.ts` の Hasura 読み取りモード（holidays / groupA / groupB）が `M2M_TOKEN` を前提にしていて、未設定だと `Missing required environment variable: M2M_TOKEN` で落ちる問題の修正。

## 修正

`run.ts` と同じく、`M2M_TOKEN` も `HASURA_ADMIN_SECRET` も無ければ Auth0 Client Credentials Flow（`fetchM2MToken`）で自動取得する。`institutions` モードは Hasura を読まないのでスキップ。

これで scraper の `.env`（AUTH0_DOMAIN/CLIENT_ID/CLIENT_SECRET/AUDIENCE）だけでシードが走る。

## 検証

typecheck / lint / knip 緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)