### PR TITLE
fix(api): wrangler.jsonc の database_id を本番 D1 に置換

### DIFF
--- a/packages/api/wrangler.jsonc
+++ b/packages/api/wrangler.jsonc
@@ -11,9 +11,8 @@
     {
       "binding": "DB",
       "database_name": "shisetsu-db",
-      // TODO(PR3-1 Task 3-1-6): `wrangler d1 create shisetsu-db` の出力で置換する。
-      // ローカル/テスト(miniflare)はこの値を使わず新規 D1 を作るためプレースホルダで動く。
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      // 本番 D1（APAC）。ローカル/テスト(miniflare)はこの値を使わず新規 D1 を作る。
+      "database_id": "353bd30e-d421-460f-821a-018fd05a455c",
       "migrations_dir": "migrations",
     },
   ],


### PR DESCRIPTION
`npx wrangler d1 migrations apply shisetsu-db --remote` が PR3-1 の TODO プレースホルダ（全ゼロ UUID）を叩いて 7404 で失敗していたため、本番 D1 `shisetsu-db` の実 id に置換する。ローカル/テスト（miniflare）はこの値を使わないため影響なし。database_id は認証なしでは操作できないリソース識別子であり、コミットして問題ない（wrangler の標準プラクティス）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)