### PR TITLE
fix(scraper): パリティ突合から Hasura の遺物行を除外する

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -393,7 +393,7 @@ jobs:
               if (tracker) {
                 await github.rest.issues.createComment({
                   owner: context.repo.owner, repo: context.repo.repo, issue_number: tracker.number,
-                  body: '直近の定期実行で Hasura と D1 の乖離は検出されませんでした。自動クローズします。',
+                  body: `直近の定期実行で Hasura と D1 の乖離は検出されませんでした（STALE ${reports.reduce((s, r) => s + (r.stale ?? 0), 0)} 件はゲート対象外）。自動クローズします。`,
                 });
                 await github.rest.issues.update({
                   owner: context.repo.owner, repo: context.repo.repo, issue_number: tracker.number,
@@ -408,10 +408,12 @@ jobs:
             let body = `${MARKER}\n\n`;
             body += `定期実行で Hasura と D1 の予約データに **${total} 件の乖離** を検出しました。\n\n`;
             body += `- MISSING: Hasura にあり D1 に無い / EXTRA: D1 にあり Hasura に無い / DIFF: 両方にあるが reservation が異なる\n`;
+            body += `- STALE: Hasura にあり D1 に無いが、Hasura 側の更新が dual-write 開始前で止まっている行。`;
+            body += `スクレイプ対象から外れた施設や horizon 外の日付で、D1 へは原理的に届かない。**乖離件数には含めない**（Issue #1622）\n`;
             body += `- 突合対象は [今日, 今日の月末 + 5 ヶ月] の窓内のみ。行キーは \`<institution_id> <date>\`\n\n`;
-            body += `| 自治体 | Hasura | D1 | MISSING | EXTRA | DIFF |\n|---|---|---|---|---|---|\n`;
+            body += `| 自治体 | Hasura | D1 | MISSING | EXTRA | DIFF | STALE |\n|---|---|---|---|---|---|---|\n`;
             for (const r of reports) {
-              body += `| ${r.target} | ${r.hasuraRows} | ${r.d1Rows} | ${r.missing} | ${r.extra} | ${r.diff} |\n`;
+              body += `| ${r.target} | ${r.hasuraRows} | ${r.d1Rows} | ${r.missing} | ${r.extra} | ${r.diff} | ${r.stale ?? 0} |\n`;
             }
             // Issue body は最大 65,536 文字。サンプルは自治体あたり 5 件だが、念のため上限を設ける。
             const MAX_SAMPLE_LINES = 100;

--- a/packages/scraper/tools/backend/parity.ts
+++ b/packages/scraper/tools/backend/parity.ts
@@ -8,11 +8,12 @@ import { graphqlRequest } from "../request.ts";
 import { exportReservations } from "./d1Api.ts";
 import {
   compareMunicipality,
+  DUAL_WRITE_LIVE_SINCE,
   reservationWindow,
   resolveParityTargets,
   totalMismatches,
 } from "./parityReport.ts";
-import type { MunicipalityReport } from "./parityReport.ts";
+import type { HasuraRow, MunicipalityReport } from "./parityReport.ts";
 
 /**
  * Hasura と D1 の予約データを突合する。
@@ -23,6 +24,9 @@ import type { MunicipalityReport } from "./parityReport.ts";
  *  1. 自治体×日付×施設ごとの件数一致
  *  2. reservation の一致（両側 canonicalize して文字列比較）
  * 突合対象は [今日, 今日の月末 + 5 ヶ月] の窓に両側そろえる（母集団ずれの偽陽性を防ぐ）。
+ * さらに Hasura 側の更新が dual-write 開始前で止まっている行は stale として突合から外す
+ * （Hasura は upsert のみで行を消さないため、スクレイプ対象外になった施設や horizon 外の
+ * 日付の行が残り続ける。D1 へは原理的に届かず、ゲートが永久に到達不能になる。Issue #1622）。
  * 乖離 0 なら "PARITY OK"、あれば行キーと差分を列挙して exit 1。
  * 併せて最終行に `PARITY_REPORT <json>`（MunicipalityReport[]）を出す。CI がこれを読む。
  */
@@ -41,18 +45,23 @@ function key(r: { institution_id: string; date: string }): string {
 async function fetchAllHasura(window: {
   from: string;
   to: string;
-}): Promise<Map<string, Map<string, string>>> {
+}): Promise<Map<string, Map<string, HasuraRow>>> {
   const instRes = await graphqlRequest<{
     institutions: { id: string; municipality: string }[];
   }>(`{ institutions { id municipality } }`);
   const idToMunicipality = new Map(instRes.institutions.map((i) => [i.id, i.municipality]));
 
-  const byMunicipality = new Map<string, Map<string, string>>();
+  const byMunicipality = new Map<string, Map<string, HasuraRow>>();
   const { from, to } = window;
   let offset = 0;
   for (;;) {
     const response = await graphqlRequest<{
-      reservations: { institution_id: string; date: string; reservation: Record<string, string> }[];
+      reservations: {
+        institution_id: string;
+        date: string;
+        reservation: Record<string, string>;
+        updated_at: string;
+      }[];
     }>(
       `query parity($from: date!, $to: date!, $limit: Int!, $offset: Int!) {
         reservations(
@@ -60,7 +69,7 @@ async function fetchAllHasura(window: {
           order_by: { id: asc }
           limit: $limit
           offset: $offset
-        ) { institution_id date reservation }
+        ) { institution_id date reservation updated_at }
       }`,
       { from, to, limit: HASURA_PAGE, offset }
     );
@@ -71,10 +80,13 @@ async function fetchAllHasura(window: {
       if (!municipality) continue;
       let map = byMunicipality.get(municipality);
       if (!map) {
-        map = new Map<string, string>();
+        map = new Map<string, HasuraRow>();
         byMunicipality.set(municipality, map);
       }
-      map.set(key(r), canonicalizeReservation(r.reservation));
+      map.set(key(r), {
+        reservation: canonicalizeReservation(r.reservation),
+        updatedAt: r.updated_at,
+      });
     }
     offset += HASURA_PAGE;
     if (batch.length < HASURA_PAGE) break;
@@ -97,6 +109,10 @@ const targets = resolveParityTargets({
   filterArg: process.argv[2],
 });
 
+// dual-write 開始前に更新が止まった Hasura 行を突合対象から外す境界。
+// 通常は既定値でよく、env は障害調査で境界を動かして影響範囲を見るための逃げ道。
+const liveSince = process.env["PARITY_LIVE_SINCE"] ?? DUAL_WRITE_LIVE_SINCE;
+
 const window = reservationWindow(new Date());
 const hasuraByMunicipality = await fetchAllHasura(window);
 
@@ -106,7 +122,7 @@ for (const target of targets) {
   const [, m] = target.split("-");
   const municipality = `MUNICIPALITY_${(m as string).toUpperCase()}`;
 
-  const hasura = hasuraByMunicipality.get(municipality) ?? new Map<string, string>();
+  const hasura = hasuraByMunicipality.get(municipality) ?? new Map<string, HasuraRow>();
   const d1Rows = await exportReservations(municipality);
   // D1 は全期間を返すので Hasura と同じ窓に絞る（ISO 日付は辞書順 = 時系列順）。
   const d1 = new Map(
@@ -115,12 +131,13 @@ for (const target of targets) {
       .map((r) => [key(r), canonicalizeReservation(r.reservation)])
   );
 
-  const report = compareMunicipality(target, hasura, d1);
+  const report = compareMunicipality(target, hasura, d1, liveSince);
   reports.push(report);
 
+  const staleNote = report.stale > 0 ? ` stale=${report.stale}` : "";
   const localMismatch = report.missing + report.extra + report.diff;
   if (localMismatch === 0) {
-    console.log(`PARITY OK ${target} rows=${report.hasuraRows}`);
+    console.log(`PARITY OK ${target} rows=${report.hasuraRows}${staleNote}`);
   } else {
     console.error(`PARITY FAIL ${target}: ${localMismatch} mismatches`);
     for (const line of report.samples) console.error(`  ${line}`);

--- a/packages/scraper/tools/backend/parityReport.test.ts
+++ b/packages/scraper/tools/backend/parityReport.test.ts
@@ -48,13 +48,22 @@ test("reservationWindow は年跨ぎでも月末を正しく出す", () => {
   assert.equal(w.to, "2027-01-31");
 });
 
+/** 生存行（dual-write 開始以降に Hasura が更新した行）を組み立てるヘルパ。 */
+const live = (reservation: string) => ({ reservation, updatedAt: "2026-07-20T00:00:00" });
+/** 遺物（dual-write 開始前で更新が止まった行）。 */
+const stale = (reservation: string) => ({ reservation, updatedAt: "2026-02-28T05:06:50" });
+const LIVE_SINCE = "2026-07-16";
+
 test("一致していれば乖離ゼロのレポートを返す", () => {
   const hasura = new Map([
+    ["id-a 2026-08-01", live('{"M":"VACANT"}')],
+    ["id-a 2026-08-02", live('{"M":"OCCUPIED"}')],
+  ]);
+  const d1 = new Map([
     ["id-a 2026-08-01", '{"M":"VACANT"}'],
     ["id-a 2026-08-02", '{"M":"OCCUPIED"}'],
   ]);
-  const d1 = new Map(hasura);
-  const report = compareMunicipality("tokyo-kita", hasura, d1);
+  const report = compareMunicipality("tokyo-kita", hasura, d1, LIVE_SINCE);
   assert.deepEqual(report, {
     target: "tokyo-kita",
     hasuraRows: 2,
@@ -62,23 +71,25 @@ test("一致していれば乖離ゼロのレポートを返す", () => {
     missing: 0,
     extra: 0,
     diff: 0,
+    stale: 0,
     samples: [],
   });
 });
 
 test("MISSING / EXTRA / DIFF をそれぞれ数え、サンプルに載せる", () => {
   const hasura = new Map([
-    ["id-a 2026-08-01", '{"M":"VACANT"}'],
-    ["id-a 2026-08-02", '{"M":"VACANT"}'],
+    ["id-a 2026-08-01", live('{"M":"VACANT"}')],
+    ["id-a 2026-08-02", live('{"M":"VACANT"}')],
   ]);
   const d1 = new Map([
     ["id-a 2026-08-02", '{"M":"OCCUPIED"}'],
     ["id-b 2026-08-03", '{"M":"VACANT"}'],
   ]);
-  const report = compareMunicipality("tokyo-kita", hasura, d1);
+  const report = compareMunicipality("tokyo-kita", hasura, d1, LIVE_SINCE);
   assert.equal(report.missing, 1);
   assert.equal(report.diff, 1);
   assert.equal(report.extra, 1);
+  assert.equal(report.stale, 0);
   assert.deepEqual(report.samples, [
     "MISSING in D1: id-a 2026-08-01",
     "DIFF: id-a 2026-08-02",
@@ -86,19 +97,60 @@ test("MISSING / EXTRA / DIFF をそれぞれ数え、サンプルに載せる", 
   ]);
 });
 
+test("D1 に無い行でも Hasura の更新が dual-write 開始前なら stale として MISSING から外す", () => {
+  const hasura = new Map([
+    ["id-a 2026-08-01", stale('{"M":"VACANT"}')],
+    ["id-a 2026-08-02", live('{"M":"VACANT"}')],
+  ]);
+  const report = compareMunicipality("tokyo-kita", hasura, new Map(), LIVE_SINCE);
+  assert.equal(report.stale, 1);
+  assert.equal(report.missing, 1);
+  // 遺物はゲート対象外なのでサンプルにも載せない（本物の乖離を埋もれさせないため）
+  assert.deepEqual(report.samples, ["MISSING in D1: id-a 2026-08-02"]);
+});
+
+test("stale だけの自治体は totalMismatches に寄与せず合格する", () => {
+  const hasura = new Map([
+    ["id-a 2026-08-01", stale('{"M":"VACANT"}')],
+    ["id-a 2026-08-02", stale('{"M":"VACANT"}')],
+  ]);
+  const report = compareMunicipality("tokyo-koutou", hasura, new Map(), LIVE_SINCE);
+  assert.equal(report.stale, 2);
+  assert.equal(report.missing, 0);
+  assert.equal(totalMismatches([report]), 0);
+});
+
+test("両方にあるが内容が違う行は更新が古くても DIFF として数える", () => {
+  // D1 に行が在る = dual-write は届いている。内容差は遺物では説明できない実バグ。
+  const hasura = new Map([["id-a 2026-08-01", stale('{"M":"VACANT"}')]]);
+  const d1 = new Map([["id-a 2026-08-01", '{"M":"OCCUPIED"}']]);
+  const report = compareMunicipality("tokyo-kita", hasura, d1, LIVE_SINCE);
+  assert.equal(report.diff, 1);
+  assert.equal(report.stale, 0);
+});
+
 test("サンプルは 5 件までに切り詰めるが、件数は全件を数える", () => {
   const hasura = new Map(
-    Array.from({ length: 8 }, (_, i) => [`id-a 2026-08-0${i + 1}`, '{"M":"VACANT"}'] as const)
+    Array.from({ length: 8 }, (_, i) => [`id-a 2026-08-0${i + 1}`, live('{"M":"VACANT"}')] as const)
   );
-  const report = compareMunicipality("tokyo-kita", hasura, new Map());
+  const report = compareMunicipality("tokyo-kita", hasura, new Map(), LIVE_SINCE);
   assert.equal(report.missing, 8);
   assert.equal(report.samples.length, 5);
 });
 
-test("totalMismatches は全自治体の missing/extra/diff を合算する", () => {
+test("totalMismatches は全自治体の missing/extra/diff を合算し stale は含めない", () => {
   const reports = [
-    { target: "a", hasuraRows: 1, d1Rows: 1, missing: 1, extra: 2, diff: 3, samples: [] },
-    { target: "b", hasuraRows: 0, d1Rows: 0, missing: 0, extra: 0, diff: 0, samples: [] },
+    {
+      target: "a",
+      hasuraRows: 1,
+      d1Rows: 1,
+      missing: 1,
+      extra: 2,
+      diff: 3,
+      stale: 99,
+      samples: [],
+    },
+    { target: "b", hasuraRows: 0, d1Rows: 0, missing: 0, extra: 0, diff: 0, stale: 0, samples: [] },
   ];
   assert.equal(totalMismatches(reports), 6);
 });

--- a/packages/scraper/tools/backend/parityReport.ts
+++ b/packages/scraper/tools/backend/parityReport.ts
@@ -23,44 +23,78 @@ export function reservationWindow(now: Date): { from: string; to: string } {
   return { from, to };
 }
 
+/**
+ * dual-write が全自治体で稼働し始めた日（この日より前に更新が止まった Hasura 行は
+ * 構造的に D1 へ来ないため、突合対象から外す）。
+ *
+ * 実測（D1 reservations の MIN(updated_at)）: chuo 2026-07-15T03:17Z、
+ * 他 8 自治体 2026-07-15T10:20〜10:38Z。全自治体が揃った翌日を安全側の境界とする。
+ * Hasura の updated_at は "YYYY-MM-DDTHH:MM:SS.ffffff" 形式で、日付前方一致の
+ * 辞書順比較がそのまま時系列比較になる。
+ */
+export const DUAL_WRITE_LIVE_SINCE = "2026-07-16";
+
+/** Hasura 側の 1 行。updatedAt は遺物（stale）判定に使う。 */
+export interface HasuraRow {
+  /** canonicalize 済み reservation 文字列 */
+  reservation: string;
+  /** Hasura の updated_at（ISO 風文字列。辞書順比較する） */
+  updatedAt: string;
+}
+
 export interface MunicipalityReport {
   target: string;
   hasuraRows: number;
   d1Rows: number;
-  /** Hasura にあり D1 に無い */
+  /** Hasura にあり D1 に無い（dual-write 開始以降に更新された行のみ）= 実バグ */
   missing: number;
   /** D1 にあり Hasura に無い */
   extra: number;
   /** 両方にあるが reservation が異なる */
   diff: number;
+  /**
+   * Hasura にあり D1 に無いが、Hasura 側の更新が dual-write 開始前で止まっている行。
+   * スクレイプ対象から外れた施設や horizon 外の日付の「Hasura にだけ残る死んだ行」で、
+   * D1 へは原理的に届かない。ゲートには含めず件数のみ報告する（Issue #1622）。
+   */
+  stale: number;
   samples: string[];
 }
 
 /**
  * 1 自治体分の Hasura / D1 を突合する。
- * 引数の Map は「行キー → canonicalize 済み reservation 文字列」。
- * 値は canonicalize 済みである前提なので、比較は素の文字列比較でよい。
+ * 値は両側とも canonicalize 済みである前提なので、比較は素の文字列比較でよい。
+ *
+ * D1 に行が存在するのに内容が違う場合（DIFF）は、Hasura 側の更新が古くても実バグとして数える。
+ * 行が届いている以上「dual-write に来なかった」では説明できないため。
  */
 export function compareMunicipality(
   target: string,
-  hasura: Map<string, string>,
-  d1: Map<string, string>
+  hasura: Map<string, HasuraRow>,
+  d1: Map<string, string>,
+  liveSince: string = DUAL_WRITE_LIVE_SINCE
 ): MunicipalityReport {
   const samples: string[] = [];
   let missing = 0;
   let extra = 0;
   let diff = 0;
+  let stale = 0;
 
   const addSample = (line: string): void => {
     if (samples.length < SAMPLE_LIMIT) samples.push(line);
   };
 
-  for (const [k, hval] of hasura) {
+  for (const [k, hrow] of hasura) {
     const dval = d1.get(k);
     if (dval === undefined) {
-      missing++;
-      addSample(`MISSING in D1: ${k}`);
-    } else if (dval !== hval) {
+      if (hrow.updatedAt < liveSince) {
+        // 遺物。サンプルにも載せない（本物の乖離を埋もれさせないため）
+        stale++;
+      } else {
+        missing++;
+        addSample(`MISSING in D1: ${k}`);
+      }
+    } else if (dval !== hrow.reservation) {
       diff++;
       addSample(`DIFF: ${k}`);
     }
@@ -72,9 +106,10 @@ export function compareMunicipality(
     }
   }
 
-  return { target, hasuraRows: hasura.size, d1Rows: d1.size, missing, extra, diff, samples };
+  return { target, hasuraRows: hasura.size, d1Rows: d1.size, missing, extra, diff, stale, samples };
 }
 
+/** ゲート判定に使う乖離件数。stale は原理的に解消しないため含めない。 */
 export function totalMismatches(reports: MunicipalityReport[]): number {
   return reports.reduce((sum, r) => sum + r.missing + r.extra + r.diff, 0);
 }


### PR DESCRIPTION
Closes #1622

## 背景

Hasura は upsert のみで行を削除しない。そのためスクレイプ対象から外れた施設や horizon 外の日付の行が残り続ける。これらは D1 へ原理的に届かないので、突合すると**永久に MISSING に見え、パリティゲートが到達不能**になっていた（Issue #1622、531 件）。

## 調査結果

MISSING 531 件の正体は「dual-write 開始（7/15）以降に一度も再書き込みされていない Hasura の遺物」であり、**D1 の書き込みバグではない**。

決定的な裏取りとして、突合窓内の Hasura 行のうち `updated_at < 7/15` の件数を全数集計したところ、Issue の MISSING と一致した。

| 自治体 | MISSING | `updated_at < 7/15` |
|---|---:|---:|
| tokyo-koutou | 41 | **41 一致** |
| tokyo-kita | 76 | **76 一致** |
| tokyo-edogawa | 51 | **51 一致** |
| toshima / ota / chuo / kawasaki | 0 | **0 一致** |

bunkyo(299) / arakawa(64) の差分は、パリティ実行後に走った日次スクレイプが治した分（arakawa `5eeb57d4` が 09:56Z に Hasura と D1 の**両方**へ書かれたことを実測確認）。

遺物が再書き込みされない理由:

- **赤羽会館/リハ室 (kita 76)** — `tokyo-kita/index.ts` の targets 13 室に存在せず、git 履歴上も一度も入っていない旧世代の残骸。同建物の講堂は 7/18 更新済み
- **上一色コミュニティセンター/集会室 (edogawa 51)** — 同建物のふれあいルームは 7/18 更新済みなのに集会室のみ 0 行。3 月以降サイトから取得できていない
- **koutou 12-01 (41)** — koutou のレンジ生成は当月から 5 レンジ＝**11-30 で終わり December を構造的に取得しない**のに、突合窓は 12-31 まで伸びる

EXTRA / DIFF は一貫してゼロで、D1 は「来たものを正しく書き、来ないものを書かない」だけだった。

## 変更内容

MISSING を `missing`（ゲート対象）と `stale`（情報のみ）に分離する。

- `parityReport.ts` — Hasura 側の値を `HasuraRow { reservation, updatedAt }` に変更し、`compareMunicipality` に `liveSince` を追加。`stale` はサンプルにも載せない（本物の乖離を埋もれさせないため）
- `parity.ts` — Hasura クエリに `updated_at` を追加。env `PARITY_LIVE_SINCE` で cutoff を上書き可能（障害調査で境界を動かすための逃げ道）
- `scraper.yml` — トラッカー Issue の本文に STALE 列と説明を追加

cutoff `DUAL_WRITE_LIVE_SINCE = "2026-07-16"` は推測ではなく、D1 の `MIN(updated_at)` 実測（chuo 7/15 03:17Z、他 8 自治体 7/15 10:20〜10:38Z）に基づき、全自治体が揃った翌日を安全側に取った。

**DIFF は `updated_at` が古くても実バグとして扱う。** D1 に行が届いている以上「dual-write に来なかった」では説明できないため。この非対称性がないと、遺物の除外が本物のバグ検知まで削ってしまう。

## 検証

- ユニットテスト 93 全緑（stale 分離 / DIFF の非対称性 / `totalMismatches` が stale を除外、の 4 ケース追加）
- typecheck・lint・format・knip 緑
- **本番データで `parity.ts` を実行し、9 自治体すべて PARITY OK**（`missing=0 / extra=0 / diff=0 / stale=503`、exit 0）

```
PARITY OK tokyo-koutou rows=5617 stale=41
PARITY OK tokyo-bunkyo rows=3231 stale=299
PARITY OK tokyo-kita rows=1745 stale=76
PARITY OK tokyo-toshima rows=6012
PARITY OK tokyo-edogawa rows=11073 stale=51
PARITY OK tokyo-arakawa rows=3345 stale=36
PARITY OK tokyo-ota rows=1701
PARITY OK tokyo-chuo rows=1169
PARITY OK kanagawa-kawasaki rows=6179
```

## 残る課題（本 PR のスコープ外）

- **墨田区**: Hasura に窓内 3006 行あるが D1 は 0 行。GitHub Actions 上でのみ失敗する環境依存の問題で、PR 3-5 カットオーバー時点でデータが消滅する。`registry.ts` の「サイト構造変化で故障中」というコメントも実態と異なる
- 赤羽会館/リハ室・上一色/集会室 はスクレイパーのカバレッジ欠落（DB に施設だけ残っている状態）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DfjNGY89Kufc4ATaa9XuV