### PR TITLE
fix(scraper): tokyo-edogawa の STATUS_MAP に「休館」を追加

### DIFF
--- a/packages/scraper/tokyo-edogawa/index.ts
+++ b/packages/scraper/tokyo-edogawa/index.ts
@@ -19,6 +19,7 @@ export const STATUS_MAP: Record<string, Status> = {
   申込期間外: "RESERVATION_STATUS_STATUS_3",
   公開対象外: "RESERVATION_STATUS_STATUS_4",
   抽選: "RESERVATION_STATUS_STATUS_5",
+  休館: "RESERVATION_STATUS_STATUS_6",
 };
 
 interface EdogawaTarget {

--- a/packages/shared/registry.ts
+++ b/packages/shared/registry.ts
@@ -179,6 +179,7 @@ export const MUNICIPALITIES = {
       [ReservationStatus.STATUS_3]: "申込期間外",
       [ReservationStatus.STATUS_4]: "公開対象外",
       [ReservationStatus.STATUS_5]: "抽選",
+      [ReservationStatus.STATUS_6]: "休館",
     },
     reservationDivision: {
       [ReservationDivision.MORNING]: "午前",


### PR DESCRIPTION
## 背景

`/spot-check`（2026-07-19、8 サンプル）の実地照合で、江戸川区 総合文化センター 研修室 2026-07-19 の D1 保存値が `RESERVATION_STATUS_INVALID` になっていることを検出した。判定結果と他の要調査項目は #1626 に記録している。

## 原因

`packages/scraper/tokyo-edogawa/index.ts` の `STATUS_MAP` に **「休館」のキーが無い**ため、サイトが表示する「休館」が未マッピング値として `INVALID` にフォールバックしていた。

さらに総合文化センターはサイトのお知らせ（掲載日 2026/4/9）によれば **令和8年4月〜令和9年11月まで全館休館の改修工事中**で、全室・全日が「休館」表示。つまり 2026-04 以降ずっと INVALID を書き込み続けていた可能性が高い。

## 変更

- `packages/scraper/tokyo-edogawa/index.ts`: `STATUS_MAP` に `休館: "RESERVATION_STATUS_STATUS_6"` を追加
- `packages/shared/registry.ts`: `MUNICIPALITY_EDOGAWA.reservationStatus` に `STATUS_6: "休館"` を追加

registry.ts が source of truth で `common/registryContract.test.ts` が scraper の `STATUS_MAP` との整合を検証するため、両方に入れる必要がある（片方だけだとテストが落ちる）。

## 検証

- `npm run test:unit -w @shisetsu-viewer/scraper` → 114 passed / 0 failed
- `npm run typecheck:all` → エラーなし
- **実サイトで再スクレイプ**（`npx playwright test tokyo-edogawa --grep "総合文化センター"` → 1 passed）:
  - 研修室 2026-07-19 の3区分すべてが `RESERVATION_STATUS_STATUS_6` になり、サイト観測「休館」と一致
  - 総合文化センター全9室 × 497 スロットすべてが `STATUS_6`（＝全館休館の実態と整合）

## 残課題

同系 `/user/Home` SPA の tokyo-bunkyo / sumida にも「休館」欠落がないかは未確認（#1626 に記載）。

Closes #1626 の項目1

🤖 Generated with [Claude Code](https://claude.com/claude-code)