### PR TITLE
chore(deps): rollup 由来の残骸と esbuild の重複宣言を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,10 +53,7 @@ updates:
         patterns:
           - "vite"
           - "@vitejs/*"
-          - "esbuild"
-          - "@esbuild/*"
           - "@swc/*"
-          - "@rollup/*"
           - "wrangler"
       linting:
         applies-to: version-updates
@@ -84,10 +81,7 @@ updates:
           - "msw"
           - "vite"
           - "@vitejs/*"
-          - "esbuild"
-          - "@esbuild/*"
           - "@swc/*"
-          - "@rollup/*"
           - "wrangler"
           - "eslint"
           - "eslint-*"

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,7 +1,7 @@
 import type { KnipConfig } from "knip";
 
 const config: KnipConfig = {
-  ignoreBinaries: ["open", "xdg-open"],
+  ignoreBinaries: ["xdg-open"],
   exclude: ["enumMembers"],
   workspaces: {
     ".": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,6 @@
       "engines": {
         "node": ">=24",
         "npm": ">=10"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.62.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3200,22 +3197,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@shisetsu-viewer/api": {
       "resolved": "packages/api",
       "link": true
@@ -4728,22 +4709,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4992,49 +4957,6 @@
       "version": "0.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/default-browser": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-      "integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -5969,19 +5891,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6227,54 +6136,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-in-ssh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -6287,22 +6148,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -7113,44 +6958,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/open/node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/openid-client": {
       "version": "6.8.4",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
@@ -7432,19 +7239,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -7700,175 +7494,6 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/rollup-plugin-visualizer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
-      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "open": "^11.0.0",
-        "picomatch": "^4.0.2",
-        "source-map": "^0.7.4",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "rollup-plugin-visualizer": "dist/bin/cli.js"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
-        "rollup": "2.x || 3.x || 4.x"
-      },
-      "peerDependenciesMeta": {
-        "rolldown": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -7893,19 +7518,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safer-buffer": {
@@ -9343,7 +8955,6 @@
         "dotenv": "17.4.2",
         "esbuild": "0.28.1",
         "msw": "2.15.0",
-        "rollup-plugin-visualizer": "7.0.1",
         "vite": "8.1.4",
         "vitest": "4.1.10",
         "wrangler": "4.110.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -805,6 +805,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8953,14 +8954,10 @@
         "@vitest/browser-playwright": "4.1.10",
         "@vitest/coverage-istanbul": "4.1.10",
         "dotenv": "17.4.2",
-        "esbuild": "0.28.1",
         "msw": "2.15.0",
         "vite": "8.1.4",
         "vitest": "4.1.10",
         "wrangler": "4.110.0"
-      },
-      "optionalDependencies": {
-        "@esbuild/linux-x64": "0.28.1"
       }
     },
     "packages/viewer/node_modules/@vitest/browser": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "4.62.2"
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -23,14 +23,10 @@
     "@vitest/browser-playwright": "4.1.10",
     "@vitest/coverage-istanbul": "4.1.10",
     "dotenv": "17.4.2",
-    "esbuild": "0.28.1",
     "msw": "2.15.0",
     "vite": "8.1.4",
     "vitest": "4.1.10",
     "wrangler": "4.110.0"
-  },
-  "optionalDependencies": {
-    "@esbuild/linux-x64": "0.28.1"
   },
   "scripts": {
     "start": "vite --port 3000",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -25,7 +25,6 @@
     "dotenv": "17.4.2",
     "esbuild": "0.28.1",
     "msw": "2.15.0",
-    "rollup-plugin-visualizer": "7.0.1",
     "vite": "8.1.4",
     "vitest": "4.1.10",
     "wrangler": "4.110.0"
@@ -36,7 +35,6 @@
   "scripts": {
     "start": "vite --port 3000",
     "build": "node ../../node_modules/typescript7/bin/tsc && vite build",
-    "build:analyze": "vite build --mode analyze",
     "serve": "vite preview --port 3000",
     "typecheck": "node ../../node_modules/typescript7/bin/tsc",
     "test": "TZ=Asia/Tokyo vitest",

--- a/packages/viewer/vite.config.ts
+++ b/packages/viewer/vite.config.ts
@@ -1,6 +1,5 @@
-import { defineConfig, type PluginOption, type UserConfig } from "vite";
+import { defineConfig, type UserConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
-import { visualizer } from "rollup-plugin-visualizer";
 
 const manualChunks: Record<string, string[]> = {
   "react-vendor": ["react", "react-dom"],
@@ -25,18 +24,5 @@ export default defineConfig(({ mode }): UserConfig => ({
       },
     },
   },
-  plugins: [
-    react(),
-    ...(mode === "analyze"
-      ? [
-          visualizer({
-            open: false,
-            filename: "dist/stats.json",
-            template: "raw-data",
-            gzipSize: true,
-            brotliSize: true,
-          }),
-        ]
-      : []),
-  ] as PluginOption[],
+  plugins: [react()],
 }));


### PR DESCRIPTION
## 背景

Vite 8 の bundler は Rolldown、transform は oxc。この移行の結果として **rollup / esbuild まわりの依存宣言が実態とずれていた**ため、まとめて整理する。

経緯は似ているが、2 つの結論は異なる。

| | 実態 | 措置 |
|---|---|---|
| **rollup** | 本体が依存ツリーに**存在しない** | 残骸を削除（機能の喪失あり・後述） |
| **esbuild** | 本体は**健在**（wrangler がハード依存）。宣言だけが冗長 | 重複宣言のみ削除（挙動の変化なし） |

---

## 1. rollup 由来の残骸

`node_modules/rollup` は存在せず、入っているのは `rolldown` + `@rolldown/binding-*` のみ。

### `@rollup/rollup-linux-x64-gnu`（root `optionalDependencies`）

`a115039 fix build error`（2025-01-11）で追加。当時 Vite 5/6 の bundler が Rollup だった頃に、npm の optional dependencies バグ（npm/cli#4828）で Linux CI が `Cannot find module @rollup/rollup-linux-x64-gnu` で落ちるのを回避したもの。

現在は参照元が無いまま、**使われないネイティブバイナリを Linux CI で毎回取得している**状態だった。macOS では os/cpu 制約でスキップされるためローカルでは気づけない。

### `rollup-plugin-visualizer` + `build:analyze`

`dist/stats.json` の消費者をリポジトリ全体で調査したが **0 件**（CI ジョブ・サイズ回帰チェック・docs いずれにも言及なし）。手動実行専用だった。

⚠️ Rolldown 1.1.3 にネイティブの visualizer 相当は無いため、**バンドル分析の手段は一旦失われる**。常設 devDependency として抱えるより必要時に一時導入する方がよい、という判断。ここだけ機能の喪失を伴うので、異論があれば戻せる。

---

## 2. esbuild の重複宣言（`packages/viewer`）

**esbuild 本体は残る。** 削除するのは viewer の直接宣言のみで、解決バージョンは `0.28.1` のまま変わらない。

| 依存元 | esbuild の扱い |
|---|---|
| vite 8.1.4 | `peerDependenciesMeta.esbuild.optional: true` → **必須ではない** |
| wrangler 4.110.0 | `dependencies` に `0.28.1` を**ハード依存** |
| @cloudflare/vitest-pool-workers 0.18.4 | `dependencies` に `0.28.1` を**ハード依存** |
| ソースコード | import **0 件** |

### `esbuild`（devDependencies）

Vite 8 の optional peer を埋めるだけの重複。wrangler 経由の解決で peer は満たされる。削除後も `npm ls esbuild` で `vite@8.1.4 └── esbuild@0.28.1 deduped` を確認済み。

### `@esbuild/linux-x64`（optionalDependencies）

rollup 側と同じ npm バグ回避の手書き宣言。ただしこちらは **esbuild 自身の `optionalDependencies` に含まれている**ため不要。削除後の lockfile にもエントリが `cpu: ["x64"]` / `os: ["linux"]` 制約付きで残存しており、`npm ci` が Linux CI で正しく解決する（これが手書き宣言不要の決定的な根拠）。

---

## 3. 副産物

- `knip.config.ts` の `ignoreBinaries` から `open` を削除。visualizer 経由の依存だったため不要になった（knip 自身が検出）。`xdg-open` は他に参照元があるため残置。
- `.github/dependabot.yml` の group パターンから `esbuild` / `@esbuild/*` / `@rollup/*` を削除。いずれも直接依存でなくなりマッチ対象が消滅した。

---

## 検証

| コマンド | 結果 |
|---|---|
| `npm run build -w @shisetsu-viewer/viewer` | ✅ built in 182ms・`manualChunks`（react-vendor）維持 |
| `npm test -w @shisetsu-viewer/api` | ✅ **77 passed / 9 files**（esbuild の実消費者 vitest-pool-workers を実走） |
| `npm run knip` | ✅ 指摘ゼロ |
| `npm run lint:all` | ✅ |
| `npm run format:check:all` | ✅ |
| `npm run typecheck:all` | ✅ 全 5 パッケージ |

`package-lock.json` 内の `rollup` 参照が **0 件**になったことを確認済み（計 381 行削除）。

## 触っていないもの

`packages/viewer/vite.config.ts` の `build.rollupOptions` は残置。これは Vite が Rolldown 移行で設定 API を壊さないために維持している**互換キー名**であり、rollup への依存ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)