### PR TITLE
chore(deps): patch 更新と msw worker script の再生成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "24.13.3",
         "eslint": "10.7.0",
         "globals": "17.7.0",
-        "knip": "6.26.0",
+        "knip": "6.27.0",
         "prettier": "3.9.5",
         "prettier-plugin-organize-imports": "4.3.0",
         "typescript": "6.0.3",
@@ -349,16 +349,16 @@
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.18.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.18.4.tgz",
-      "integrity": "sha512-jOXvyLoR2b8jFvo3tX+mWxXXwcZ+PbId3d7vGFtZsuKakmDjKSeIq4o/sQjkqNv6q3XacIKSCAvfM8TfkPyrEw==",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.18.5.tgz",
+      "integrity": "sha512-Qe00zuHDRyAsOO7DmHnPcOhCiShdkt/NlRf/GrnKHzuXuysmt5YVyU/WaMVPqEkPYrgO+H9bSEJ1c9/7Nbw1Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cjs-module-lexer": "1.2.3",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260708.1",
-        "wrangler": "4.110.0",
+        "miniflare": "4.20260710.0",
+        "wrangler": "4.111.0",
         "zod": "3.25.76"
       },
       "peerDependencies": {
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260708.1.tgz",
-      "integrity": "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg==",
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260710.1.tgz",
+      "integrity": "sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw==",
       "cpu": [
         "x64"
       ],
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260708.1.tgz",
-      "integrity": "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA==",
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260710.1.tgz",
+      "integrity": "sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw==",
       "cpu": [
         "arm64"
       ],
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260708.1.tgz",
-      "integrity": "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA==",
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260710.1.tgz",
+      "integrity": "sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ==",
       "cpu": [
         "x64"
       ],
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260708.1.tgz",
-      "integrity": "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA==",
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260710.1.tgz",
+      "integrity": "sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA==",
       "cpu": [
         "arm64"
       ],
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260708.1.tgz",
-      "integrity": "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA==",
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260710.1.tgz",
+      "integrity": "sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw==",
       "cpu": [
         "x64"
       ],
@@ -6283,9 +6283,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.26.0.tgz",
-      "integrity": "sha512-e9eELEEpBpGTd4H4HB7818/DYj9dMzMyUqAddfYwUN/EbSkgIjOuWEF96W/xHsmV0SDrsdXjIM+oZ2xpPzPsBA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.27.0.tgz",
+      "integrity": "sha512-CngYEYrD0n20N06FXA8n3u/0Wnnugoa+B9k14OP+iKIgkCHuzvIdsP3nfwjhByoc1WfogpxfiriMboAXFETDUw==",
       "dev": true,
       "funding": [
         {
@@ -6759,16 +6759,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260708.1",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260708.1.tgz",
-      "integrity": "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA==",
+      "version": "4.20260710.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260710.0.tgz",
+      "integrity": "sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260708.1",
+        "workerd": "1.20260710.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -6862,9 +6862,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7212,9 +7212,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -8257,16 +8257,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -8466,9 +8466,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260708.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260708.1.tgz",
-      "integrity": "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w==",
+      "version": "1.20260710.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260710.1.tgz",
+      "integrity": "sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -8479,11 +8479,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260708.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260708.1",
-        "@cloudflare/workerd-linux-64": "1.20260708.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260708.1",
-        "@cloudflare/workerd-windows-64": "1.20260708.1"
+        "@cloudflare/workerd-darwin-64": "1.20260710.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260710.1",
+        "@cloudflare/workerd-linux-64": "1.20260710.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260710.1",
+        "@cloudflare/workerd-windows-64": "1.20260710.1"
       }
     },
     "node_modules/wouter": {
@@ -8501,9 +8501,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.110.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.110.0.tgz",
-      "integrity": "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg==",
+      "version": "4.111.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.111.0.tgz",
+      "integrity": "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -8511,10 +8511,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260708.1",
+        "miniflare": "4.20260710.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260708.1"
+        "workerd": "1.20260710.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -8528,7 +8528,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260708.1"
+        "@cloudflare/workers-types": "^5.20260710.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -8702,9 +8702,9 @@
         "jose": "6.2.3"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "0.18.4",
+        "@cloudflare/vitest-pool-workers": "0.18.5",
         "vitest": "4.1.10",
-        "wrangler": "4.110.0"
+        "wrangler": "4.111.0"
       }
     },
     "packages/api/node_modules/@vitest/expect": {
@@ -8955,9 +8955,9 @@
         "@vitest/coverage-istanbul": "4.1.10",
         "dotenv": "17.4.2",
         "msw": "2.15.0",
-        "vite": "8.1.4",
+        "vite": "8.1.5",
         "vitest": "4.1.10",
-        "wrangler": "4.110.0"
+        "wrangler": "4.111.0"
       }
     },
     "packages/viewer/node_modules/@vitest/browser": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/node": "24.13.3",
     "eslint": "10.7.0",
     "globals": "17.7.0",
-    "knip": "6.26.0",
+    "knip": "6.27.0",
     "prettier": "3.9.5",
     "prettier-plugin-organize-imports": "4.3.0",
     "typescript": "6.0.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,8 +17,8 @@
     "jose": "6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "0.18.4",
+    "@cloudflare/vitest-pool-workers": "0.18.5",
     "vitest": "4.1.10",
-    "wrangler": "4.110.0"
+    "wrangler": "4.111.0"
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -24,9 +24,9 @@
     "@vitest/coverage-istanbul": "4.1.10",
     "dotenv": "17.4.2",
     "msw": "2.15.0",
-    "vite": "8.1.4",
+    "vite": "8.1.5",
     "vitest": "4.1.10",
-    "wrangler": "4.110.0"
+    "wrangler": "4.111.0"
   },
   "scripts": {
     "start": "vite --port 3000",

--- a/packages/viewer/public/mockServiceWorker.js
+++ b/packages/viewer/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.11.3'
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -137,8 +137,18 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
   if (client && activeClientIds.has(client.id)) {
     const serializedRequest = await serializeRequest(requestCloneForEvents)
 
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone()
+    const responseClone = isEventStreamResponse ? null : response.clone()
 
     sendToClient(
       client,
@@ -151,15 +161,17 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
             ...serializedRequest,
           },
           response: {
-            type: responseClone.type,
-            status: responseClone.status,
-            statusText: responseClone.statusText,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-            body: responseClone.body,
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
     )
   }
 
@@ -205,6 +217,7 @@ async function resolveMainClient(event) {
  * @param {FetchEvent} event
  * @param {Client | undefined} client
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  * @returns {Promise<Response>}
  */
 async function getResponse(event, client, requestId, requestInterceptedAt) {


### PR DESCRIPTION
## 概要

ライブラリモダン化の第1弾（A-5）。patch 差分の更新と、放置されていた MSW worker script の再生成。

- vite 8.1.4 → 8.1.5
- wrangler 4.110.0 → 4.111.0（viewer / api）
- @cloudflare/vitest-pool-workers 0.18.4 → 0.18.5
- knip 6.26.0 → 6.27.0
- `public/mockServiceWorker.js` を msw 2.15.0 で再生成（2.11.3 生成のままで、テスト実行時に互換性警告が出ていた）

## 検証

- `npm run typecheck:all` ✅
- `npm run build` ✅
- viewer: 555 tests / 56 files ✅
- api: 77 tests / 9 files ✅
- `npm run knip` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)