### PR TITLE
chore(deps): viewer から未使用の dotenv を削除

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,7 +12,6 @@ const config: KnipConfig = {
     "packages/viewer": {
       ignoreDependencies: [
         "@swc/core", // used internally by @vitejs/plugin-react-swc
-        "dotenv", // used via --require dotenv/config in generate script
       ],
     },
     "packages/scraper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4994,19 +4994,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dpop": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/dpop/-/dpop-2.1.1.tgz",
@@ -8953,7 +8940,6 @@
         "@vitest/browser": "4.1.10",
         "@vitest/browser-playwright": "4.1.10",
         "@vitest/coverage-istanbul": "4.1.10",
-        "dotenv": "17.4.2",
         "msw": "2.15.0",
         "vite": "8.1.4",
         "vitest": "4.1.10",

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -22,7 +22,6 @@
     "@vitest/browser": "4.1.10",
     "@vitest/browser-playwright": "4.1.10",
     "@vitest/coverage-istanbul": "4.1.10",
-    "dotenv": "17.4.2",
     "msw": "2.15.0",
     "vite": "8.1.4",
     "vitest": "4.1.10",

--- a/packages/viewer/playwright.config.ts
+++ b/packages/viewer/playwright.config.ts
@@ -1,14 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
 /**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
-
-/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({


### PR DESCRIPTION
## 概要

ライブラリモダン化の第2弾（A-3）。dotenv 17 が viewer の devDependencies に残っていたが、実際の参照は playwright.config.ts の Playwright 雛形コメント（コメントアウトされた `import dotenv from 'dotenv'`）のみで、実 import はゼロだった。

knip が検出しなかったのは `knip.config.ts` の ignoreDependencies に「generate script で `--require dotenv/config` 経由で使用」として登録されていたため。この generate script は現存しない（全ファイル grep で確認）ので、ignore エントリごと削除。

なお scraper 側は既に `node --env-file` を使用しており、将来 Playwright config で env が必要になった場合も Node 組込の `process.loadEnvFile()` で代替できる。

## 変更

- `packages/viewer/package.json`: dotenv 削除
- `packages/viewer/playwright.config.ts`: 雛形コメント削除
- `knip.config.ts`: 陳腐化した ignore エントリ削除

## 検証

- `npm run knip` ✅（ignore 削除後も検出なし）
- `npm run typecheck:all` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)