### PR TITLE
test: @testing-library/react から vitest-browser-react v2 へ移行

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,11 +38,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@adobe/css-tools": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@auth0/auth0-auth-js": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@auth0/auth0-auth-js/-/auth0-auth-js-1.10.0.tgz",
@@ -255,16 +250,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3245,80 +3230,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@testing-library/react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@tsconfig/strictest": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.8.tgz",
@@ -3336,12 +3247,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4300,14 +4205,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/aria-query": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4618,11 +4515,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css.escape": {
-      "version": "1.5.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4671,14 +4563,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4688,14 +4572,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dpop": {
       "version": "2.1.1",
@@ -5774,16 +5650,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6327,15 +6193,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6438,14 +6295,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/miniflare": {
@@ -6971,32 +6820,6 @@
         }
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7078,24 +6901,6 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/regexparam": {
@@ -7550,17 +7355,6 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -8115,6 +7909,31 @@
         }
       }
     },
+    "node_modules/vitest-browser-react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vitest-browser-react/-/vitest-browser-react-2.2.0.tgz",
+      "integrity": "sha512-oY3KM6305kwJMa6nHo92vVtkOsih7mjEf12dLKuphaF+9ywWPEc+qanIBd394SZ6m5LadVEaG6dicvvizOzmjA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "vitest": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -8634,17 +8453,15 @@
       },
       "devDependencies": {
         "@playwright/test": "1.61.1",
-        "@testing-library/jest-dom": "6.9.1",
-        "@testing-library/react": "16.3.2",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.3",
-        "@vitest/browser": "4.1.10",
         "@vitest/browser-playwright": "4.1.10",
         "@vitest/coverage-istanbul": "4.1.10",
         "msw": "2.15.0",
         "vite": "8.1.5",
         "vitest": "4.1.10",
+        "vitest-browser-react": "2.2.0",
         "wrangler": "4.111.0"
       }
     },

--- a/packages/viewer/App.test.tsx
+++ b/packages/viewer/App.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
 import { describe, expect, it, vi } from "vitest";
 import App from "./App";
 import { Auth0Context } from "./contexts/Auth0";
@@ -12,14 +13,14 @@ const auth0Value = {
 };
 
 describe("App", () => {
-  it("プロバイダ構成を通してヘッダーごとマウントされる", () => {
-    render(
+  it("プロバイダ構成を通してヘッダーごとマウントされる", async () => {
+    await render(
       <Auth0Context.Provider value={auth0Value}>
         <App />
       </Auth0Context.Provider>
     );
     // App は自前の Router を持つため二重ラップしない。ヘッダー（banner）が
     // 描画されれば ErrorBoundary/ColorModeProvider/Router/Header の合成が成立している。
-    expect(screen.getByRole("banner")).toBeInTheDocument();
+    await expect.element(page.getByRole("banner")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/CLAUDE.md
+++ b/packages/viewer/CLAUDE.md
@@ -12,8 +12,9 @@ React 19 SPA for browsing facility reservation data. Deployed to Cloudflare Work
 
 ## Testing
 
-- Vitest 4 browser mode（Chromium via Playwright provider）。`test/browser-setup.ts` が Auth0Client mock・MSW 2 worker・polyfill を初期化。
-- `renderWithProviders()`（`test/utils/test-utils.tsx`）が MockAuth0Provider + wouter memoryLocation でラップし、`user`（vitest/browser userEvent）を返す。Testing Library ユーティリティも再輸出。
+- Vitest 4 browser mode（Chromium via Playwright provider）+ vitest-browser-react。`test/browser-setup.ts` が Auth0Client mock・MSW 2 worker・polyfill を初期化。
+- `renderWithProviders()`（`test/utils/test-utils.tsx`）は **async**。MockAuth0Provider + wouter memoryLocation でラップし、`user`（vitest/browser userEvent）+ RenderResult（locator セレクタ）を返す。`screen` は `page`（locator。遅延評価・自動リトライ）の再輸出。
+- assertion は `await expect.element(locator).toBeInTheDocument()` 形式。queryBy*/findBy*/getAllBy* は存在しない（不在確認は getBy + not、複数要素は `.all()`）。**Playwright locator の `getByText` は部分一致がデフォルト**なので、衝突し得る短い文字列には `{ exact: true }` を付ける。DOM 直接アクセスは `.element()` を挟む。
 - MSW worker の生成が必要: `npx msw init public -w @shisetsu-viewer/viewer`
 - E2E: Playwright（`e2e/`、chromium/firefox/webkit）。dev server は `webServer` 設定で自動起動。
 - Coverage thresholds: branches/functions 60%, lines/statements 70%。

--- a/packages/viewer/components/Box/Box.test.tsx
+++ b/packages/viewer/components/Box/Box.test.tsx
@@ -6,25 +6,25 @@ import { FullBox } from "./FullBox";
 import { SmallBox } from "./SmallBox";
 
 describe("BaseBox", () => {
-  it("正しくレンダリングされる", () => {
-    renderWithProviders(<BaseBox data-testid="base-box">テスト</BaseBox>);
-    expect(screen.getByTestId("base-box")).toBeInTheDocument();
+  it("正しくレンダリングされる", async () => {
+    await renderWithProviders(<BaseBox data-testid="base-box">テスト</BaseBox>);
+    await expect.element(screen.getByTestId("base-box")).toBeInTheDocument();
   });
 });
 
 describe("Sized Box variants", () => {
-  it("SmallBoxがレンダリングされる", () => {
-    renderWithProviders(<SmallBox data-testid="small-box">小</SmallBox>);
-    expect(screen.getByTestId("small-box")).toBeInTheDocument();
+  it("SmallBoxがレンダリングされる", async () => {
+    await renderWithProviders(<SmallBox data-testid="small-box">小</SmallBox>);
+    await expect.element(screen.getByTestId("small-box")).toBeInTheDocument();
   });
 
-  it("AutoBoxがレンダリングされる", () => {
-    renderWithProviders(<AutoBox data-testid="auto-box">自動</AutoBox>);
-    expect(screen.getByTestId("auto-box")).toBeInTheDocument();
+  it("AutoBoxがレンダリングされる", async () => {
+    await renderWithProviders(<AutoBox data-testid="auto-box">自動</AutoBox>);
+    await expect.element(screen.getByTestId("auto-box")).toBeInTheDocument();
   });
 
-  it("FullBoxがレンダリングされる", () => {
-    renderWithProviders(<FullBox data-testid="full-box">全幅</FullBox>);
-    expect(screen.getByTestId("full-box")).toBeInTheDocument();
+  it("FullBoxがレンダリングされる", async () => {
+    await renderWithProviders(<FullBox data-testid="full-box">全幅</FullBox>);
+    await expect.element(screen.getByTestId("full-box")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Checkbox/Checkbox.test.tsx
+++ b/packages/viewer/components/Checkbox/Checkbox.test.tsx
@@ -4,36 +4,36 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { Checkbox } from "./Checkbox";
 
 describe("Checkbox Component", () => {
-  it("ラベルを表示する", () => {
-    renderWithProviders(<Checkbox label="利用可能" value="available" />);
+  it("ラベルを表示する", async () => {
+    await renderWithProviders(<Checkbox label="利用可能" value="available" />);
 
-    expect(screen.getByText("利用可能")).toBeInTheDocument();
+    await expect.element(screen.getByText("利用可能")).toBeInTheDocument();
   });
 
-  it("未チェック状態を表示する", () => {
-    renderWithProviders(<Checkbox label="利用可能" value="available" checked={false} />);
+  it("未チェック状態を表示する", async () => {
+    await renderWithProviders(<Checkbox label="利用可能" value="available" checked={false} />);
 
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).not.toBeChecked();
+    await expect.element(checkbox).not.toBeChecked();
   });
 
-  it("チェック状態を表示する", () => {
-    renderWithProviders(<Checkbox label="利用可能" value="available" checked={true} />);
+  it("チェック状態を表示する", async () => {
+    await renderWithProviders(<Checkbox label="利用可能" value="available" checked={true} />);
 
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toBeChecked();
+    await expect.element(checkbox).toBeChecked();
   });
 
-  it("デフォルトでは未チェック状態", () => {
-    renderWithProviders(<Checkbox label="利用可能" value="available" />);
+  it("デフォルトでは未チェック状態", async () => {
+    await renderWithProviders(<Checkbox label="利用可能" value="available" />);
 
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).not.toBeChecked();
+    await expect.element(checkbox).not.toBeChecked();
   });
 
   it("クリック時にonChangeが呼ばれる", async () => {
     const handleChange = vi.fn();
-    const { user } = renderWithProviders(
+    const { user } = await renderWithProviders(
       <Checkbox label="利用可能" value="available" onChange={handleChange} />
     );
 
@@ -43,26 +43,26 @@ describe("Checkbox Component", () => {
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 
-  it("チェックボックスに正しいvalue属性を持つ", () => {
-    renderWithProviders(<Checkbox label="利用可能" value="available" />);
+  it("チェックボックスに正しいvalue属性を持つ", async () => {
+    await renderWithProviders(<Checkbox label="利用可能" value="available" />);
 
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveAttribute("value", "available");
+    await expect.element(checkbox).toHaveAttribute("value", "available");
   });
 
   it("onChangeを渡さない場合にデフォルトのonChangeが使われる", async () => {
-    const { user } = renderWithProviders(<Checkbox label="テスト" value="test" />);
+    const { user } = await renderWithProviders(<Checkbox label="テスト" value="test" />);
 
     const checkbox = screen.getByRole("checkbox");
     // Should not throw when clicking without onChange handler
     await user.click(checkbox);
 
-    expect(checkbox).toBeInTheDocument();
+    await expect.element(checkbox).toBeInTheDocument();
   });
 
-  it("sizeプロパティを指定してレンダリングする", () => {
-    renderWithProviders(<Checkbox label="テスト" value="test" size="small" />);
+  it("sizeプロパティを指定してレンダリングする", async () => {
+    await renderWithProviders(<Checkbox label="テスト" value="test" size="small" />);
 
-    expect(screen.getByText("テスト")).toBeInTheDocument();
+    await expect.element(screen.getByText("テスト")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/packages/viewer/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -11,18 +11,18 @@ describe("CheckboxGroup Component", () => {
     onChange: vi.fn(),
   };
 
-  it("ラベルを表示する", () => {
-    renderWithProviders(
+  it("ラベルを表示する", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps}>
         <Checkbox label="体育館" value="gym" />
       </CheckboxGroup>
     );
 
-    expect(screen.getByText("施設種別")).toBeInTheDocument();
+    await expect.element(screen.getByText("施設種別")).toBeInTheDocument();
   });
 
-  it("子要素のチェックボックスをレンダリングする", () => {
-    renderWithProviders(
+  it("子要素のチェックボックスをレンダリングする", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps}>
         <Checkbox label="体育館" value="gym" />
         <Checkbox label="テニスコート" value="tennis" />
@@ -30,13 +30,13 @@ describe("CheckboxGroup Component", () => {
       </CheckboxGroup>
     );
 
-    expect(screen.getByText("体育館")).toBeInTheDocument();
-    expect(screen.getByText("テニスコート")).toBeInTheDocument();
-    expect(screen.getByText("プール")).toBeInTheDocument();
+    await expect.element(screen.getByText("体育館")).toBeInTheDocument();
+    await expect.element(screen.getByText("テニスコート")).toBeInTheDocument();
+    await expect.element(screen.getByText("プール")).toBeInTheDocument();
   });
 
-  it("valuesに含まれるチェックボックスがチェック状態になる", () => {
-    renderWithProviders(
+  it("valuesに含まれるチェックボックスがチェック状態になる", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={["gym", "pool"]}>
         <Checkbox label="体育館" value="gym" />
         <Checkbox label="テニスコート" value="tennis" />
@@ -44,57 +44,57 @@ describe("CheckboxGroup Component", () => {
       </CheckboxGroup>
     );
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = screen.getByRole("checkbox").all();
     // gym should be checked
-    expect(checkboxes[0]).toBeChecked();
+    await expect.element(checkboxes[0]!).toBeChecked();
     // tennis should not be checked
-    expect(checkboxes[1]).not.toBeChecked();
+    await expect.element(checkboxes[1]!).not.toBeChecked();
     // pool should be checked
-    expect(checkboxes[2]).toBeChecked();
+    await expect.element(checkboxes[2]!).toBeChecked();
   });
 
-  it("valuesが空の場合すべて未チェック状態", () => {
-    renderWithProviders(
+  it("valuesが空の場合すべて未チェック状態", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={[]}>
         <Checkbox label="体育館" value="gym" />
         <Checkbox label="テニスコート" value="tennis" />
       </CheckboxGroup>
     );
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    checkboxes.forEach((checkbox) => {
-      expect(checkbox).not.toBeChecked();
-    });
+    const checkboxes = screen.getByRole("checkbox").all();
+    for (const checkbox of checkboxes) {
+      await expect.element(checkbox).not.toBeChecked();
+    }
   });
 
   it("チェックボックスをクリックするとonChangeが呼ばれる", async () => {
     const handleChange = vi.fn();
-    const { user } = renderWithProviders(
+    const { user } = await renderWithProviders(
       <CheckboxGroup {...defaultProps} onChange={handleChange}>
         <Checkbox label="体育館" value="gym" />
         <Checkbox label="テニスコート" value="tennis" />
       </CheckboxGroup>
     );
 
-    const checkbox = screen.getAllByRole("checkbox")[0]!;
+    const checkbox = screen.getByRole("checkbox").all()[0]!;
     await user.click(checkbox);
 
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 
-  it("チェックボックスのvalue属性が正しく設定される", () => {
-    renderWithProviders(
+  it("チェックボックスのvalue属性が正しく設定される", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={["gym"]}>
         <Checkbox label="体育館" value="gym" />
       </CheckboxGroup>
     );
 
     const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toHaveAttribute("value", "gym");
+    await expect.element(checkbox).toHaveAttribute("value", "gym");
   });
 
-  it("ネストされた要素内のチェックボックスを再帰的に処理する", () => {
-    renderWithProviders(
+  it("ネストされた要素内のチェックボックスを再帰的に処理する", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={["gym", "pool"]}>
         <div>
           <Checkbox label="体育館" value="gym" />
@@ -103,13 +103,13 @@ describe("CheckboxGroup Component", () => {
       </CheckboxGroup>
     );
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes[0]).toBeChecked();
-    expect(checkboxes[1]).toBeChecked();
+    const checkboxes = screen.getByRole("checkbox").all();
+    await expect.element(checkboxes[0]!).toBeChecked();
+    await expect.element(checkboxes[1]!).toBeChecked();
   });
 
-  it("Checkbox以外の子要素はnullを返す", () => {
-    renderWithProviders(
+  it("Checkbox以外の子要素はnullを返す", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={[]}>
         <Checkbox label="体育館" value="gym" />
         {null}
@@ -117,12 +117,12 @@ describe("CheckboxGroup Component", () => {
       </CheckboxGroup>
     );
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = screen.getByRole("checkbox").all();
     expect(checkboxes).toHaveLength(1);
   });
 
-  it("子要素なしのCheckbox以外の要素はnullを返す", () => {
-    renderWithProviders(
+  it("子要素なしのCheckbox以外の要素はnullを返す", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={["gym"]}>
         <Checkbox label="体育館" value="gym" />
         <hr />
@@ -131,22 +131,22 @@ describe("CheckboxGroup Component", () => {
 
     // The <hr /> element is not a Checkbox and has no children,
     // so mapChildren returns null for it
-    const checkboxes = screen.getAllByRole("checkbox");
+    const checkboxes = screen.getByRole("checkbox").all();
     expect(checkboxes).toHaveLength(1);
-    expect(checkboxes[0]).toBeChecked();
+    await expect.element(checkboxes[0]!).toBeChecked();
   });
 
-  it("value属性のないCheckboxはchecked=falseになる", () => {
-    renderWithProviders(
+  it("value属性のないCheckboxはchecked=falseになる", async () => {
+    await renderWithProviders(
       <CheckboxGroup {...defaultProps} values={["gym"]}>
         <Checkbox label="体育館" value="gym" />
         <Checkbox label="不明" value="" />
       </CheckboxGroup>
     );
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes[0]).toBeChecked();
+    const checkboxes = screen.getByRole("checkbox").all();
+    await expect.element(checkboxes[0]!).toBeChecked();
     // Checkbox with empty string value should not be checked
-    expect(checkboxes[1]).not.toBeChecked();
+    await expect.element(checkboxes[1]!).not.toBeChecked();
   });
 });

--- a/packages/viewer/components/DataTable/DataTable.test.tsx
+++ b/packages/viewer/components/DataTable/DataTable.test.tsx
@@ -61,45 +61,45 @@ describe("DataTable Component", () => {
     mockIsMobile.value = false;
   });
 
-  it("カラムヘッダーを表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("カラムヘッダーを表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
-    expect(screen.getByText("名前")).toBeInTheDocument();
-    expect(screen.getByText("年齢")).toBeInTheDocument();
-    expect(screen.getByText("ラベル")).toBeInTheDocument();
+    await expect.element(screen.getByText("名前")).toBeInTheDocument();
+    await expect.element(screen.getByText("年齢")).toBeInTheDocument();
+    await expect.element(screen.getByText("ラベル")).toBeInTheDocument();
   });
 
-  it("行データを正しく表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("行データを正しく表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
-    expect(screen.getByText("東京")).toBeInTheDocument();
-    expect(screen.getByText("100")).toBeInTheDocument();
-    expect(screen.getByText("川崎")).toBeInTheDocument();
-    expect(screen.getByText("200")).toBeInTheDocument();
+    await expect.element(screen.getByText("東京", { exact: true })).toBeInTheDocument();
+    await expect.element(screen.getByText("100", { exact: true })).toBeInTheDocument();
+    await expect.element(screen.getByText("川崎", { exact: true })).toBeInTheDocument();
+    await expect.element(screen.getByText("200", { exact: true })).toBeInTheDocument();
   });
 
-  it("getter型のカラムはvalueGetterの結果を表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("getter型のカラムはvalueGetterの結果を表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
-    expect(screen.getByText("東京-100")).toBeInTheDocument();
-    expect(screen.getByText("川崎-200")).toBeInTheDocument();
+    await expect.element(screen.getByText("東京-100")).toBeInTheDocument();
+    await expect.element(screen.getByText("川崎-200")).toBeInTheDocument();
   });
 
-  it("hide=trueのカラムは表示しない", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("hide=trueのカラムは表示しない", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
-    expect(screen.queryByText("非表示列")).not.toBeInTheDocument();
-    expect(screen.queryByText("秘密1")).not.toBeInTheDocument();
-    expect(screen.queryByText("秘密2")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("非表示列")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("秘密1")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("秘密2")).not.toBeInTheDocument();
   });
 
   it("行クリックでonRowClickコールバックが呼ばれる", async () => {
     const onRowClick = vi.fn();
-    const { user } = renderWithProviders(
+    const { user } = await renderWithProviders(
       <DataTable columns={columns} rows={rows} onRowClick={onRowClick} />
     );
 
-    await user.click(screen.getByText("東京"));
+    await user.click(screen.getByText("東京", { exact: true }));
 
     expect(onRowClick).toHaveBeenCalledOnce();
     expect(onRowClick).toHaveBeenCalledWith({
@@ -110,71 +110,71 @@ describe("DataTable Component", () => {
     });
   });
 
-  it("hasNextPage=trueの場合にスケルトンローディングを表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={true} />);
+  it("hasNextPage=trueの場合にスケルトンローディングを表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={true} />);
 
     // The skeleton row should contain skeleton elements (one per visible column)
     const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
     expect(skeletons.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("hasNextPage=falseの場合はスケルトンを表示しない", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={false} />);
+  it("hasNextPage=falseの場合はスケルトンを表示しない", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={false} />);
 
     const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
     expect(skeletons.length).toBe(0);
   });
 
-  it("行がない場合はヘッダーのみ表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={[]} />);
+  it("行がない場合はヘッダーのみ表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={[]} />);
 
-    expect(screen.getByText("名前")).toBeInTheDocument();
-    expect(screen.getByText("年齢")).toBeInTheDocument();
-    expect(screen.getByText("ラベル")).toBeInTheDocument();
+    await expect.element(screen.getByText("名前")).toBeInTheDocument();
+    await expect.element(screen.getByText("年齢")).toBeInTheDocument();
+    await expect.element(screen.getByText("ラベル")).toBeInTheDocument();
   });
 
-  it("getter型でvalueGetterが未定義の場合は空文字を表示する", () => {
+  it("getter型でvalueGetterが未定義の場合は空文字を表示する", async () => {
     const colsWithoutGetter: Columns<TestRow> = [
       { field: "name", headerName: "名前", type: "string" },
       { field: "label", headerName: "ラベル", type: "getter" },
     ];
-    renderWithProviders(<DataTable columns={colsWithoutGetter} rows={rows} />);
+    await renderWithProviders(<DataTable columns={colsWithoutGetter} rows={rows} />);
 
-    expect(screen.getByText("名前")).toBeInTheDocument();
-    expect(screen.getByText("ラベル")).toBeInTheDocument();
+    await expect.element(screen.getByText("名前")).toBeInTheDocument();
+    await expect.element(screen.getByText("ラベル")).toBeInTheDocument();
   });
 
   describe("Column Types", () => {
-    it("date型のカラムはformatDateの結果を表示する", () => {
-      renderWithProviders(<DataTable columns={columns} rows={rows} />);
+    it("date型のカラムはformatDateの結果を表示する", async () => {
+      await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
       // formatDate uses Intl.DateTimeFormat "ja-JP" with year/month/day/weekday
       // 2025-01-15 → "2025/01/15(水)"
-      expect(screen.getByText("作成日")).toBeInTheDocument();
+      await expect.element(screen.getByText("作成日")).toBeInTheDocument();
       const cells = document.querySelectorAll("td");
       const cellTexts = Array.from(cells).map((c) => c.textContent);
       expect(cellTexts.some((t) => t?.includes("2025"))).toBe(true);
     });
 
-    it("datetime型のカラムはformatDatetimeの結果を表示する", () => {
-      renderWithProviders(<DataTable columns={columns} rows={rows} />);
+    it("datetime型のカラムはformatDatetimeの結果を表示する", async () => {
+      await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
-      expect(screen.getByText("更新日時")).toBeInTheDocument();
+      await expect.element(screen.getByText("更新日時")).toBeInTheDocument();
       const cells = document.querySelectorAll("td");
       const cellTexts = Array.from(cells).map((c) => c.textContent);
       // datetime format includes time components
       expect(cellTexts.some((t) => t?.includes("2025") && t?.includes(":"))).toBe(true);
     });
 
-    it("number型のカラムは数値を表示する", () => {
-      renderWithProviders(<DataTable columns={columns} rows={rows} />);
+    it("number型のカラムは数値を表示する", async () => {
+      await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
-      expect(screen.getByText("スコア")).toBeInTheDocument();
-      expect(screen.getByText("95")).toBeInTheDocument();
-      expect(screen.getByText("80")).toBeInTheDocument();
+      await expect.element(screen.getByText("スコア")).toBeInTheDocument();
+      await expect.element(screen.getByText("95")).toBeInTheDocument();
+      await expect.element(screen.getByText("80")).toBeInTheDocument();
     });
 
-    it("number型でNaNの場合は空文字を表示する", () => {
+    it("number型でNaNの場合は空文字を表示する", async () => {
       const nanRows: TestRow[] = [
         {
           id: "3",
@@ -187,7 +187,7 @@ describe("DataTable Component", () => {
           score: "not-a-number",
         },
       ];
-      renderWithProviders(<DataTable columns={columns} rows={nanRows} />);
+      await renderWithProviders(<DataTable columns={columns} rows={nanRows} />);
 
       // The score column should render empty string for NaN
       const tableCells = document.querySelectorAll("td");
@@ -201,14 +201,14 @@ describe("DataTable Component", () => {
   });
 
   describe("IntersectionObserver", () => {
-    it("fetchMoreが設定されている場合にIntersectionObserverが動作する", () => {
+    it("fetchMoreが設定されている場合にIntersectionObserverが動作する", async () => {
       const fetchMore = vi.fn().mockResolvedValue(undefined);
-      renderWithProviders(
+      await renderWithProviders(
         <DataTable columns={columns} rows={rows} fetchMore={fetchMore} hasNextPage={true} />
       );
 
       // The component should render without error with fetchMore
-      expect(screen.getByText("東京")).toBeInTheDocument();
+      await expect.element(screen.getByText("東京", { exact: true })).toBeInTheDocument();
     });
 
     it("十分な行数がある場合にIntersectionObserverが要素をobserveする", async () => {
@@ -224,7 +224,7 @@ describe("DataTable Component", () => {
       }));
 
       const fetchMore = vi.fn().mockResolvedValue(undefined);
-      renderWithProviders(
+      await renderWithProviders(
         <DataTable columns={columns} rows={manyRows} fetchMore={fetchMore} hasNextPage={true} />
       );
 
@@ -251,7 +251,7 @@ describe("DataTable Component", () => {
       }));
 
       const fetchMore = vi.fn().mockResolvedValue(undefined);
-      renderWithProviders(
+      await renderWithProviders(
         <DataTable columns={columns} rows={fewRows} fetchMore={fetchMore} hasNextPage={true} />
       );
 
@@ -273,7 +273,7 @@ describe("DataTable Component", () => {
       }));
 
       const fetchMore = vi.fn().mockResolvedValue(undefined);
-      const { unmount } = renderWithProviders(
+      const { unmount } = await renderWithProviders(
         <DataTable columns={columns} rows={manyRows} fetchMore={fetchMore} hasNextPage={true} />
       );
 
@@ -281,7 +281,7 @@ describe("DataTable Component", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Unmounting should trigger cleanup (observer.unobserve)
-      unmount();
+      await unmount();
     });
   });
 });
@@ -295,37 +295,37 @@ describe("Mobile Card View", () => {
     mockIsMobile.value = false;
   });
 
-  it("モバイルではカードビューを表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("モバイルではカードビューを表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
     // In card view, the first column becomes the title, remaining become label-value pairs
     // Should NOT have a <table> element
     expect(document.querySelector("table")).toBeNull();
 
     // Should display row data as cards
-    expect(screen.getByText("東京")).toBeInTheDocument();
-    expect(screen.getByText("川崎")).toBeInTheDocument();
+    await expect.element(screen.getByText("東京", { exact: true })).toBeInTheDocument();
+    await expect.element(screen.getByText("川崎", { exact: true })).toBeInTheDocument();
 
     // Detail columns should show labels (headerName) for non-title columns
-    expect(screen.getAllByText("年齢").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("ラベル").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("年齢").all().length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("ラベル").all().length).toBeGreaterThanOrEqual(1);
   });
 
-  it("モバイルでhide=trueのカラムは表示しない", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("モバイルでhide=trueのカラムは表示しない", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
     // hide=true columns should not appear even in card view
-    expect(screen.queryByText("秘密1")).not.toBeInTheDocument();
-    expect(screen.queryByText("秘密2")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("秘密1")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("秘密2")).not.toBeInTheDocument();
   });
 
   it("モバイルで行クリックでonRowClickが呼ばれる", async () => {
     const onRowClick = vi.fn();
-    const { user } = renderWithProviders(
+    const { user } = await renderWithProviders(
       <DataTable columns={columns} rows={rows} onRowClick={onRowClick} />
     );
 
-    await user.click(screen.getByText("東京"));
+    await user.click(screen.getByText("東京", { exact: true }));
 
     expect(onRowClick).toHaveBeenCalledOnce();
     expect(onRowClick).toHaveBeenCalledWith({
@@ -336,36 +336,36 @@ describe("Mobile Card View", () => {
     });
   });
 
-  it("モバイルでhasNextPage=trueの場合にスケルトンを表示する", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={true} />);
+  it("モバイルでhasNextPage=trueの場合にスケルトンを表示する", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={true} />);
 
     const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
     expect(skeletons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("モバイルでhasNextPage=falseの場合はスケルトンを表示しない", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={false} />);
+  it("モバイルでhasNextPage=falseの場合はスケルトンを表示しない", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} hasNextPage={false} />);
 
     const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
     expect(skeletons.length).toBe(0);
   });
 
-  it("モバイルでgetterやdate型の値がカードに表示される", () => {
-    renderWithProviders(<DataTable columns={columns} rows={rows} />);
+  it("モバイルでgetterやdate型の値がカードに表示される", async () => {
+    await renderWithProviders(<DataTable columns={columns} rows={rows} />);
 
     // getter column values
-    expect(screen.getByText("東京-100")).toBeInTheDocument();
-    expect(screen.getByText("川崎-200")).toBeInTheDocument();
+    await expect.element(screen.getByText("東京-100")).toBeInTheDocument();
+    await expect.element(screen.getByText("川崎-200")).toBeInTheDocument();
   });
 
-  it("モバイルでfetchMoreが設定されている場合にIntersectionObserverが動作する", () => {
+  it("モバイルでfetchMoreが設定されている場合にIntersectionObserverが動作する", async () => {
     const fetchMore = vi.fn().mockResolvedValue(undefined);
-    renderWithProviders(
+    await renderWithProviders(
       <DataTable columns={columns} rows={rows} fetchMore={fetchMore} hasNextPage={true} />
     );
 
     // Should render without error in mobile mode with fetchMore
-    expect(screen.getByText("東京")).toBeInTheDocument();
+    await expect.element(screen.getByText("東京", { exact: true })).toBeInTheDocument();
   });
 
   it("モバイルで十分な行数がある場合にcardTargetのIntersectionObserverが動作する", async () => {
@@ -381,7 +381,7 @@ describe("Mobile Card View", () => {
     }));
 
     const fetchMore = vi.fn().mockResolvedValue(undefined);
-    renderWithProviders(
+    await renderWithProviders(
       <DataTable columns={columns} rows={manyRows} fetchMore={fetchMore} hasNextPage={true} />
     );
 

--- a/packages/viewer/components/DatePicker/DatePicker.test.tsx
+++ b/packages/viewer/components/DatePicker/DatePicker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderWithProviders, screen, fireEvent } from "../../test/utils/test-utils";
+import { renderWithProviders } from "../../test/utils/test-utils";
 import { DatePicker } from "./DatePicker";
 
 describe("DatePicker Component", () => {
@@ -10,42 +10,45 @@ describe("DatePicker Component", () => {
     maxDate: new Date(2021, 11, 31),
   };
 
-  it("date入力フィールドを表示する", () => {
-    renderWithProviders(<DatePicker {...defaultProps} />);
-    const input = screen.getByDisplayValue("2021-01-15");
-    expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute("type", "date");
+  it("date入力フィールドを表示する", async () => {
+    await renderWithProviders(<DatePicker {...defaultProps} />);
+    const input = document.querySelector<HTMLInputElement>('input[type="date"]')!;
+    await expect.element(input).toHaveValue("2021-01-15");
+    await expect.element(input).toHaveAttribute("type", "date");
   });
 
-  it("選択された日付の値を表示する", () => {
-    renderWithProviders(<DatePicker {...defaultProps} />);
-    expect(screen.getByDisplayValue("2021-01-15")).toBeInTheDocument();
+  it("選択された日付の値を表示する", async () => {
+    await renderWithProviders(<DatePicker {...defaultProps} />);
+    const input = document.querySelector<HTMLInputElement>('input[type="date"]')!;
+    await expect.element(input).toHaveValue("2021-01-15");
   });
 
-  it("minとmax属性が設定される", () => {
+  it("minとmax属性が設定される", async () => {
     const minDate = new Date(2021, 5, 1);
     const maxDate = new Date(2021, 5, 30);
 
-    renderWithProviders(<DatePicker {...defaultProps} minDate={minDate} maxDate={maxDate} />);
+    await renderWithProviders(<DatePicker {...defaultProps} minDate={minDate} maxDate={maxDate} />);
 
-    const input = screen.getByDisplayValue("2021-01-15");
-    expect(input).toHaveAttribute("min", "2021-06-01");
-    expect(input).toHaveAttribute("max", "2021-06-30");
+    const input = document.querySelector<HTMLInputElement>('input[type="date"]')!;
+    await expect.element(input).toHaveAttribute("min", "2021-06-01");
+    await expect.element(input).toHaveAttribute("max", "2021-06-30");
   });
 
-  it("日付変更時にonChangeが呼ばれる", () => {
+  it("日付変更時にonChangeが呼ばれる", async () => {
     const onChange = vi.fn();
-    renderWithProviders(<DatePicker {...defaultProps} onChange={onChange} />);
+    const { user } = await renderWithProviders(
+      <DatePicker {...defaultProps} onChange={onChange} />
+    );
 
-    const input = screen.getByDisplayValue("2021-01-15");
-    fireEvent.change(input, { target: { value: "2021-03-20" } });
+    const input = document.querySelector<HTMLInputElement>('input[type="date"]')!;
+    await user.fill(input, "2021-03-20");
 
     expect(onChange).toHaveBeenCalledWith(new Date(2021, 2, 20));
   });
 
-  it("valueがnullの場合、空文字を表示する", () => {
-    renderWithProviders(<DatePicker {...defaultProps} value={null} />);
-    const input = document.querySelector('input[type="date"]');
-    expect(input).toHaveAttribute("value", "");
+  it("valueがnullの場合、空文字を表示する", async () => {
+    await renderWithProviders(<DatePicker {...defaultProps} value={null} />);
+    const input = document.querySelector<HTMLInputElement>('input[type="date"]');
+    await expect.element(input).toHaveAttribute("value", "");
   });
 });

--- a/packages/viewer/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/packages/viewer/components/DateRangePicker/DateRangePicker.test.tsx
@@ -19,35 +19,36 @@ describe("DateRangePicker Component", () => {
     },
   };
 
-  it("ラベルを表示する", () => {
-    renderWithProviders(<DateRangePicker {...defaultProps} />);
+  it("ラベルを表示する", async () => {
+    await renderWithProviders(<DateRangePicker {...defaultProps} />);
 
-    expect(screen.getByText("期間")).toBeInTheDocument();
+    await expect.element(screen.getByText("期間")).toBeInTheDocument();
   });
 
-  it("2つの日付ピッカーを表示する", () => {
-    renderWithProviders(<DateRangePicker {...defaultProps} />);
+  it("2つの日付ピッカーを表示する", async () => {
+    await renderWithProviders(<DateRangePicker {...defaultProps} />);
 
     const dateInputs = document.querySelectorAll('input[type="date"]');
     expect(dateInputs).toHaveLength(2);
   });
 
-  it("開始日と終了日の間に「〜」セパレーターを表示する", () => {
-    renderWithProviders(<DateRangePicker {...defaultProps} />);
+  it("開始日と終了日の間に「〜」セパレーターを表示する", async () => {
+    await renderWithProviders(<DateRangePicker {...defaultProps} />);
 
-    expect(screen.getByText("〜")).toBeInTheDocument();
+    await expect.element(screen.getByText("〜")).toBeInTheDocument();
   });
 
-  it("開始日と終了日の値を正しく表示する", () => {
-    renderWithProviders(<DateRangePicker {...defaultProps} />);
+  it("開始日と終了日の値を正しく表示する", async () => {
+    await renderWithProviders(<DateRangePicker {...defaultProps} />);
 
-    expect(screen.getByDisplayValue("2021-01-01")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("2021-02-01")).toBeInTheDocument();
+    const dateInputs = document.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    await expect.element(dateInputs[0]!).toHaveValue("2021-01-01");
+    await expect.element(dateInputs[1]!).toHaveValue("2021-02-01");
   });
 
-  it("異なるラベルテキストを表示する", () => {
-    renderWithProviders(<DateRangePicker {...defaultProps} label="日付範囲" />);
+  it("異なるラベルテキストを表示する", async () => {
+    await renderWithProviders(<DateRangePicker {...defaultProps} label="日付範囲" />);
 
-    expect(screen.getByText("日付範囲")).toBeInTheDocument();
+    await expect.element(screen.getByText("日付範囲")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Header/Header.test.tsx
+++ b/packages/viewer/components/Header/Header.test.tsx
@@ -13,69 +13,73 @@ vi.mock("../../contexts/ColorMode", () => ({
 }));
 
 describe("Header Component", () => {
-  it("ロゴがトップページにリンクされている", () => {
+  it("ロゴがトップページにリンクされている", async () => {
     mockUseIsMobile.mockReturnValue(false);
-    renderWithProviders(<Header />);
+    await renderWithProviders(<Header />);
 
     const logo = screen.getByAltText("Shisetsu Viewer");
-    expect(logo).toBeInTheDocument();
+    await expect.element(logo).toBeInTheDocument();
 
-    const link = logo.closest("a");
-    expect(link).toHaveAttribute("href", "/");
+    const link = logo.element().closest("a");
+    await expect.element(link!).toHaveAttribute("href", "/");
   });
 
-  it("デスクトップで施設検索リンクを表示する", () => {
+  it("デスクトップで施設検索リンクを表示する", async () => {
     mockUseIsMobile.mockReturnValue(false);
-    renderWithProviders(<Header />);
+    await renderWithProviders(<Header />);
 
     const institutionLink = screen.getByText("施設検索");
-    expect(institutionLink).toBeInTheDocument();
-    expect(institutionLink.closest("a")).toHaveAttribute("href", "/institution");
+    await expect.element(institutionLink).toBeInTheDocument();
+    await expect
+      .element(institutionLink.element().closest("a")!)
+      .toHaveAttribute("href", "/institution");
   });
 
-  it("デスクトップで予約検索リンクを表示する", () => {
+  it("デスクトップで予約検索リンクを表示する", async () => {
     mockUseIsMobile.mockReturnValue(false);
-    renderWithProviders(<Header />, {
+    await renderWithProviders(<Header />, {
       auth0Config: { userInfo: { anonymous: false, trial: false } },
     });
 
     const reservationLink = screen.getByText("予約検索");
-    expect(reservationLink).toBeInTheDocument();
-    expect(reservationLink.closest("a")).toHaveAttribute("href", "/reservation");
+    await expect.element(reservationLink).toBeInTheDocument();
+    await expect
+      .element(reservationLink.element().closest("a")!)
+      .toHaveAttribute("href", "/reservation");
   });
 
-  it("anonymousユーザーの場合、予約検索はリンクではなくspanとして表示される", () => {
+  it("anonymousユーザーの場合、予約検索はリンクではなくspanとして表示される", async () => {
     mockUseIsMobile.mockReturnValue(false);
-    renderWithProviders(<Header />, {
+    await renderWithProviders(<Header />, {
       auth0Config: { userInfo: { anonymous: true, trial: false } },
     });
 
     const reservationText = screen.getByText("予約検索");
-    expect(reservationText).toBeInTheDocument();
-    expect(reservationText.tagName.toLowerCase()).toBe("span");
-    expect(reservationText.closest("a")).toBeNull();
+    await expect.element(reservationText).toBeInTheDocument();
+    expect(reservationText.element().tagName.toLowerCase()).toBe("span");
+    expect(reservationText.element().closest("a")).toBeNull();
   });
 
-  it("trialユーザーの場合、予約検索に（トライアル）が付与される", () => {
+  it("trialユーザーの場合、予約検索に（トライアル）が付与される", async () => {
     mockUseIsMobile.mockReturnValue(false);
-    renderWithProviders(<Header />, {
+    await renderWithProviders(<Header />, {
       auth0Config: { userInfo: { anonymous: false, trial: true } },
     });
 
-    expect(screen.getByText("予約検索（トライアル）")).toBeInTheDocument();
+    await expect.element(screen.getByText("予約検索（トライアル）")).toBeInTheDocument();
   });
 
-  it("モバイルではナビゲーションリンクを表示しない", () => {
+  it("モバイルではナビゲーションリンクを表示しない", async () => {
     mockUseIsMobile.mockReturnValue(true);
-    renderWithProviders(<Header />);
+    await renderWithProviders(<Header />);
 
-    expect(screen.queryByText("施設検索")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("施設検索")).not.toBeInTheDocument();
   });
 
-  it("モバイルではハンバーガーメニューボタンを表示する", () => {
+  it("モバイルではハンバーガーメニューボタンを表示する", async () => {
     mockUseIsMobile.mockReturnValue(true);
-    renderWithProviders(<Header />);
+    await renderWithProviders(<Header />);
 
-    expect(screen.getByRole("button", { name: "メニュー" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "メニュー" })).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/HeaderMenuButton/HeaderMenuButton.test.tsx
+++ b/packages/viewer/components/HeaderMenuButton/HeaderMenuButton.test.tsx
@@ -3,68 +3,70 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { HeaderMenuButton } from "./HeaderMenuButton";
 
 describe("HeaderMenuButton", () => {
-  it("メニューボタンをレンダリングする", () => {
-    renderWithProviders(<HeaderMenuButton />);
-    expect(screen.getByRole("button", { name: "メニュー" })).toBeInTheDocument();
+  it("メニューボタンをレンダリングする", async () => {
+    await renderWithProviders(<HeaderMenuButton />);
+    await expect.element(screen.getByRole("button", { name: "メニュー" })).toBeInTheDocument();
   });
 
   it("クリックでメニューが開く", async () => {
-    const { user } = renderWithProviders(<HeaderMenuButton />);
+    const { user } = await renderWithProviders(<HeaderMenuButton />);
 
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
-    expect(screen.getByRole("menu", { name: "ナビゲーション" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("menu", { name: "ナビゲーション" })).toBeInTheDocument();
   });
 
   it("Escapeキーでメニューが閉じる", async () => {
-    const { user } = renderWithProviders(<HeaderMenuButton />);
+    const { user } = await renderWithProviders(<HeaderMenuButton />);
 
     await user.click(screen.getByRole("button", { name: "メニュー" }));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await expect.element(screen.getByRole("menu")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await expect.element(screen.getByRole("menu")).not.toBeInTheDocument();
   });
 
   it("anonymousユーザーの場合、予約検索がリンクでなくspanで表示される", async () => {
-    const { user } = renderWithProviders(<HeaderMenuButton />, {
+    const { user } = await renderWithProviders(<HeaderMenuButton />, {
       auth0Config: { userInfo: { anonymous: true, trial: false } },
     });
 
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
-    const reservationText = await screen.findByText("予約検索");
-    expect(reservationText.tagName).toBe("SPAN");
+    const reservationText = screen.getByText("予約検索");
+    await expect.element(reservationText).toBeInTheDocument();
+    expect(reservationText.element().tagName).toBe("SPAN");
   });
 
   it("認証済みユーザーの場合、予約検索がリンクで表示される", async () => {
-    const { user } = renderWithProviders(<HeaderMenuButton />, {
+    const { user } = await renderWithProviders(<HeaderMenuButton />, {
       auth0Config: { userInfo: { anonymous: false, trial: false } },
     });
 
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
-    const reservationLink = await screen.findByText("予約検索");
-    expect(reservationLink.tagName).toBe("A");
+    const reservationLink = screen.getByText("予約検索");
+    await expect.element(reservationLink).toBeInTheDocument();
+    expect(reservationLink.element().tagName).toBe("A");
   });
 
   it("トライアルユーザーの場合、予約検索にトライアル表示が付く", async () => {
-    const { user } = renderWithProviders(<HeaderMenuButton />, {
+    const { user } = await renderWithProviders(<HeaderMenuButton />, {
       auth0Config: { userInfo: { anonymous: false, trial: true } },
     });
 
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
-    const reservationLink = await screen.findByText("予約検索（トライアル）");
-    expect(reservationLink).toBeInTheDocument();
+    await expect.element(screen.getByText("予約検索（トライアル）")).toBeInTheDocument();
   });
 
   it("施設検索リンクが常に表示される", async () => {
-    const { user } = renderWithProviders(<HeaderMenuButton />);
+    const { user } = await renderWithProviders(<HeaderMenuButton />);
 
     await user.click(screen.getByRole("button", { name: "メニュー" }));
 
-    const institutionLink = await screen.findByText("施設検索");
-    expect(institutionLink.tagName).toBe("A");
+    const institutionLink = screen.getByText("施設検索");
+    await expect.element(institutionLink).toBeInTheDocument();
+    expect(institutionLink.element().tagName).toBe("A");
   });
 });

--- a/packages/viewer/components/IconButton/IconButton.test.tsx
+++ b/packages/viewer/components/IconButton/IconButton.test.tsx
@@ -3,8 +3,8 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { IconButton } from "./IconButton";
 
 describe("IconButton", () => {
-  it("正しくレンダリングされる", () => {
-    renderWithProviders(<IconButton aria-label="テストボタン">X</IconButton>);
-    expect(screen.getByRole("button", { name: "テストボタン" })).toBeInTheDocument();
+  it("正しくレンダリングされる", async () => {
+    await renderWithProviders(<IconButton aria-label="テストボタン">X</IconButton>);
+    await expect.element(screen.getByRole("button", { name: "テストボタン" })).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Input/Input.test.tsx
+++ b/packages/viewer/components/Input/Input.test.tsx
@@ -3,53 +3,53 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { Input } from "./Input";
 
 describe("Input Component", () => {
-  it("ラベルを表示する", () => {
-    renderWithProviders(<Input label="名前" />);
+  it("ラベルを表示する", async () => {
+    await renderWithProviders(<Input label="名前" />);
 
-    expect(screen.getByText("名前")).toBeInTheDocument();
+    await expect.element(screen.getByText("名前")).toBeInTheDocument();
   });
 
-  it("値を表示する", () => {
-    renderWithProviders(<Input label="名前" value="テスト値" readOnly />);
+  it("値を表示する", async () => {
+    await renderWithProviders(<Input label="名前" value="テスト値" readOnly />);
 
     const input = screen.getByRole("textbox");
-    expect(input).toHaveValue("テスト値");
+    await expect.element(input).toHaveValue("テスト値");
   });
 
-  it("loading=trueのときSkeletonを表示する", () => {
-    const { container } = renderWithProviders(<Input label="名前" loading={true} />);
+  it("loading=trueのときSkeletonを表示する", async () => {
+    const { container } = await renderWithProviders(<Input label="名前" loading={true} />);
 
     // Skeleton is rendered, no textbox should be present
-    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-    const skeleton = container.querySelector('[data-testid="skeleton"]');
-    expect(skeleton).toBeInTheDocument();
+    await expect.element(screen.getByRole("textbox")).not.toBeInTheDocument();
+    const skeleton = container.querySelector<HTMLElement>('[data-testid="skeleton"]');
+    await expect.element(skeleton).toBeInTheDocument();
   });
 
-  it("loading=falseのときInputを表示する", () => {
-    renderWithProviders(<Input label="名前" loading={false} />);
+  it("loading=falseのときInputを表示する", async () => {
+    await renderWithProviders(<Input label="名前" loading={false} />);
 
-    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    await expect.element(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  it("readOnly属性を処理する", () => {
-    renderWithProviders(<Input label="名前" readOnly value="読み取り専用" />);
+  it("readOnly属性を処理する", async () => {
+    await renderWithProviders(<Input label="名前" readOnly value="読み取り専用" />);
 
     const input = screen.getByRole("textbox");
-    expect(input).toHaveAttribute("readonly");
+    await expect.element(input).toHaveAttribute("readonly");
   });
 
-  it("multiline属性を処理する", () => {
-    renderWithProviders(<Input label="説明" multiline rows={3} />);
+  it("multiline属性を処理する", async () => {
+    await renderWithProviders(<Input label="説明" multiline rows={3} />);
 
     const textarea = screen.getByRole("textbox");
-    expect(textarea).toBeInTheDocument();
-    expect(textarea.tagName.toLowerCase()).toBe("textarea");
+    await expect.element(textarea).toBeInTheDocument();
+    expect(textarea.element().tagName.toLowerCase()).toBe("textarea");
   });
 
-  it("値が未指定の場合は空文字を表示する", () => {
-    renderWithProviders(<Input label="名前" />);
+  it("値が未指定の場合は空文字を表示する", async () => {
+    await renderWithProviders(<Input label="名前" />);
 
     const input = screen.getByRole("textbox");
-    expect(input).toHaveValue("");
+    await expect.element(input).toHaveValue("");
   });
 });

--- a/packages/viewer/components/Label/Label.test.tsx
+++ b/packages/viewer/components/Label/Label.test.tsx
@@ -4,21 +4,21 @@ import { BaseLabel } from "./BaseLabel";
 import { SmallLabel } from "./SmallLabel";
 
 describe("BaseLabel", () => {
-  it("ラベルテキストをレンダリングする", () => {
-    renderWithProviders(<BaseLabel label="テスト" size="medium" />);
-    expect(screen.getByText("テスト")).toBeInTheDocument();
+  it("ラベルテキストをレンダリングする", async () => {
+    await renderWithProviders(<BaseLabel label="テスト" size="medium" />);
+    await expect.element(screen.getByText("テスト")).toBeInTheDocument();
   });
 
-  it("カスタムas propでレンダリングする", () => {
-    renderWithProviders(<BaseLabel label="見出し" size="large" as="h2" />);
+  it("カスタムas propでレンダリングする", async () => {
+    await renderWithProviders(<BaseLabel label="見出し" size="large" as="h2" />);
     const heading = screen.getByText("見出し");
-    expect(heading.tagName).toBe("H2");
+    expect(heading.element().tagName).toBe("H2");
   });
 });
 
 describe("SmallLabel", () => {
-  it("正しくレンダリングされる", () => {
-    renderWithProviders(<SmallLabel label="小ラベル" />);
-    expect(screen.getByText("小ラベル")).toBeInTheDocument();
+  it("正しくレンダリングされる", async () => {
+    await renderWithProviders(<SmallLabel label="小ラベル" />);
+    await expect.element(screen.getByText("小ラベル")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/SearchForm/SearchForm.test.tsx
+++ b/packages/viewer/components/SearchForm/SearchForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderWithProviders, screen, waitFor } from "../../test/utils/test-utils";
+import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { SearchForm } from "./SearchForm";
 
 // Create a mock function that can be controlled
@@ -26,36 +26,36 @@ describe("SearchForm Component", () => {
   });
 
   describe("Rendering", () => {
-    it("すべてのチップを表示する", () => {
-      renderWithProviders(<SearchForm {...defaultProps} />);
+    it("すべてのチップを表示する", async () => {
+      await renderWithProviders(<SearchForm {...defaultProps} />);
 
-      defaultProps.chips.forEach((chip) => {
-        expect(screen.getByText(chip.label)).toBeInTheDocument();
-      });
+      for (const chip of defaultProps.chips) {
+        await expect.element(screen.getByText(chip.label)).toBeInTheDocument();
+      }
     });
 
-    it("絞り込みアイコンボタンを表示する", () => {
-      renderWithProviders(<SearchForm {...defaultProps} />);
+    it("絞り込みアイコンボタンを表示する", async () => {
+      await renderWithProviders(<SearchForm {...defaultProps} />);
 
       const button = screen.getByRole("button", { name: /絞り込み/i });
-      expect(button).toBeInTheDocument();
-      expect(button.querySelector("svg")).not.toBeNull();
+      await expect.element(button).toBeInTheDocument();
+      expect(button.element().querySelector("svg")).not.toBeNull();
     });
 
-    it("チップが空の場合も正しく表示する", () => {
-      renderWithProviders(
+    it("チップが空の場合も正しく表示する", async () => {
+      await renderWithProviders(
         <SearchForm chips={[]}>
           <div>Content</div>
         </SearchForm>
       );
 
-      expect(screen.getByRole("button", { name: /絞り込み/i })).toBeInTheDocument();
+      await expect.element(screen.getByRole("button", { name: /絞り込み/i })).toBeInTheDocument();
     });
   });
 
   describe("Chip Delete", () => {
-    it("onDeleteが設定されたチップに削除ボタンが表示される", () => {
-      renderWithProviders(<SearchForm {...defaultProps} />);
+    it("onDeleteが設定されたチップに削除ボタンが表示される", async () => {
+      await renderWithProviders(<SearchForm {...defaultProps} />);
 
       const chips = document.querySelectorAll('[data-testid="chip"]');
       const deletableChips = document.querySelectorAll('[data-testid="chip-delete"]');
@@ -68,7 +68,7 @@ describe("SearchForm Component", () => {
     it("削除ボタンクリックでonDeleteが呼ばれる", async () => {
       const onDelete = vi.fn();
       const chips = [{ label: "テスト", onDelete }];
-      const { user } = renderWithProviders(
+      const { user } = await renderWithProviders(
         <SearchForm chips={chips}>
           <div>Content</div>
         </SearchForm>
@@ -84,18 +84,16 @@ describe("SearchForm Component", () => {
 
   describe("Interactions", () => {
     it("絞り込みボタンクリックでドロワーが開く", async () => {
-      const { user } = renderWithProviders(<SearchForm {...defaultProps} />);
+      const { user } = await renderWithProviders(<SearchForm {...defaultProps} />);
 
       const button = screen.getByRole("button", { name: /絞り込み/i });
       await user.click(button);
 
-      await waitFor(() => {
-        expect(screen.getByText("Search Form Content")).toBeVisible();
-      });
+      await expect.element(screen.getByText("Search Form Content")).toBeVisible();
     });
 
     it("ドロワーの閉じるボタンでドロワーが閉じる", async () => {
-      const { user } = renderWithProviders(<SearchForm {...defaultProps} />);
+      const { user } = await renderWithProviders(<SearchForm {...defaultProps} />);
 
       // Open drawer
       const openButton = screen.getByRole("button", { name: /絞り込み/i });
@@ -105,16 +103,17 @@ describe("SearchForm Component", () => {
       const closeButton = screen.getByRole("button", { name: "閉じる" });
       await user.click(closeButton);
 
-      await waitFor(() => {
-        expect(screen.queryByTestId("drawer-overlay")).not.toBeInTheDocument();
-      });
+      await expect.element(screen.getByTestId("drawer-overlay")).not.toBeInTheDocument();
     });
 
     it("ドロワーの外側クリックで閉じる", async () => {
-      const { user } = renderWithProviders(<SearchForm {...defaultProps} />);
+      const { user } = await renderWithProviders(<SearchForm {...defaultProps} />);
 
       const button = screen.getByRole("button", { name: /絞り込み/i });
       await user.click(button);
+
+      // Wait for the overlay to appear before locating it via the DOM
+      await expect.element(screen.getByTestId("drawer-overlay")).toBeInTheDocument();
 
       // Click overlay
       const overlay = document.querySelector('[data-testid="drawer-overlay"]');
@@ -122,9 +121,7 @@ describe("SearchForm Component", () => {
         await user.click(overlay as Element);
       }
 
-      await waitFor(() => {
-        expect(screen.queryByTestId("drawer-overlay")).not.toBeInTheDocument();
-      });
+      await expect.element(screen.getByTestId("drawer-overlay")).not.toBeInTheDocument();
     });
   });
 
@@ -137,8 +134,8 @@ describe("SearchForm Component", () => {
       mockIsMobileValue = false;
     });
 
-    it("モバイルビューで小さいチップサイズを使用する", () => {
-      renderWithProviders(<SearchForm {...defaultProps} />);
+    it("モバイルビューで小さいチップサイズを使用する", async () => {
+      await renderWithProviders(<SearchForm {...defaultProps} />);
 
       const chips = document.querySelectorAll('[data-testid="chip"]');
       chips.forEach((chip) => {
@@ -158,16 +155,16 @@ describe("SearchForm Component", () => {
         mockIsMobileValue = false;
       });
 
-      it("適切なARIA属性を持つ", () => {
-        renderWithProviders(<SearchForm {...defaultProps} />);
+      it("適切なARIA属性を持つ", async () => {
+        await renderWithProviders(<SearchForm {...defaultProps} />);
 
         const button = screen.getByRole("button", { name: /絞り込み/i });
-        expect(button).toBeInTheDocument();
+        await expect.element(button).toBeInTheDocument();
       });
 
       it("キーボードナビゲーションが機能する", async () => {
         const chips = [{ label: "東京都" }, { label: "体育館" }];
-        const { user } = renderWithProviders(
+        const { user } = await renderWithProviders(
           <SearchForm chips={chips}>
             <div>Search Form Content</div>
           </SearchForm>
@@ -176,20 +173,18 @@ describe("SearchForm Component", () => {
         // Tab to button
         await user.tab();
         const button = screen.getByRole("button", { name: /絞り込み/i });
-        expect(button).toHaveFocus();
+        await expect.element(button).toHaveFocus();
 
         // Enter to open
         await user.keyboard("{Enter}");
 
-        await waitFor(() => {
-          expect(screen.getByText("Search Form Content")).toBeVisible();
-        });
+        await expect.element(screen.getByText("Search Form Content")).toBeVisible();
       });
     });
   });
 
   describe("Edge Cases", () => {
-    it("非常に長いチップテキストを適切に処理する", () => {
+    it("非常に長いチップテキストを適切に処理する", async () => {
       const longChips = [
         {
           label:
@@ -198,32 +193,32 @@ describe("SearchForm Component", () => {
         { label: "もう一つの長いテキスト" },
       ];
 
-      renderWithProviders(
+      await renderWithProviders(
         <SearchForm chips={longChips}>
           <div>Content</div>
         </SearchForm>
       );
 
       // チップが表示されることを確認
-      longChips.forEach((chip) => {
+      for (const chip of longChips) {
         const chipText = chip.label.length > 20 ? chip.label.substring(0, 20) : chip.label;
-        expect(screen.getByText(chipText, { exact: false })).toBeInTheDocument();
-      });
+        await expect.element(screen.getByText(chipText, { exact: false })).toBeInTheDocument();
+      }
     });
 
-    it("多数のチップを水平スクロールで表示する", () => {
+    it("多数のチップを水平スクロールで表示する", async () => {
       const manyChips = Array.from({ length: 20 }, (_, i) => ({
         label: `チップ${i + 1}`,
       }));
 
-      renderWithProviders(
+      await renderWithProviders(
         <SearchForm chips={manyChips}>
           <div>Content</div>
         </SearchForm>
       );
 
       // 多数のチップが表示されることを確認
-      const displayedChips = screen.getAllByText(/チップ\d+/);
+      const displayedChips = screen.getByText(/チップ\d+/).all();
       expect(displayedChips.length).toBeGreaterThan(0);
       expect(displayedChips.length).toBeLessThanOrEqual(20);
     });

--- a/packages/viewer/components/SearchPageLayout/SearchPageLayout.test.tsx
+++ b/packages/viewer/components/SearchPageLayout/SearchPageLayout.test.tsx
@@ -18,23 +18,27 @@ const baseProps = {
 };
 
 describe("SearchPageLayout", () => {
-  test("loading 中は Spinner を表示する", () => {
-    renderWithProviders(<SearchPageLayout {...baseProps} loading={true} empty={false} rows={[]} />);
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  test("loading 中は Spinner を表示する", async () => {
+    await renderWithProviders(
+      <SearchPageLayout {...baseProps} loading={true} empty={false} rows={[]} />
+    );
+    await expect.element(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
-  test("empty のときデータなしメッセージを表示する", () => {
-    renderWithProviders(<SearchPageLayout {...baseProps} loading={false} empty={true} rows={[]} />);
-    expect(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
+  test("empty のときデータなしメッセージを表示する", async () => {
+    await renderWithProviders(
+      <SearchPageLayout {...baseProps} loading={false} empty={true} rows={[]} />
+    );
+    await expect.element(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
   });
 
-  test("データがあるとき DataTable の行を表示する", () => {
-    renderWithProviders(<SearchPageLayout {...baseProps} loading={false} empty={false} />);
-    expect(screen.getByText("施設A")).toBeInTheDocument();
+  test("データがあるとき DataTable の行を表示する", async () => {
+    await renderWithProviders(<SearchPageLayout {...baseProps} loading={false} empty={false} />);
+    await expect.element(screen.getByText("施設A")).toBeInTheDocument();
   });
 
-  test("error があるとき Snackbar にメッセージを表示する", () => {
-    renderWithProviders(
+  test("error があるとき Snackbar にメッセージを表示する", async () => {
+    await renderWithProviders(
       <SearchPageLayout
         {...baseProps}
         loading={false}
@@ -42,12 +46,12 @@ describe("SearchPageLayout", () => {
         error={new Error("失敗しました")}
       />
     );
-    expect(screen.getByText("失敗しました")).toBeInTheDocument();
+    await expect.element(screen.getByText("失敗しました")).toBeInTheDocument();
   });
 
   test("行クリックで onRowClick が呼ばれる", async () => {
     const onRowClick = vi.fn();
-    const { user } = renderWithProviders(
+    const { user } = await renderWithProviders(
       <SearchPageLayout {...baseProps} loading={false} empty={false} onRowClick={onRowClick} />
     );
     await user.click(screen.getByText("施設A"));

--- a/packages/viewer/components/Select/Select.test.tsx
+++ b/packages/viewer/components/Select/Select.test.tsx
@@ -10,35 +10,35 @@ const selectOptions = [
 ];
 
 describe("Select Component", () => {
-  it("ラベルを表示する", () => {
-    renderWithProviders(
+  it("ラベルを表示する", async () => {
+    await renderWithProviders(
       <Select label="地域" value="tokyo" onChange={vi.fn()} selectOptions={selectOptions} />
     );
 
-    expect(screen.getByText("地域")).toBeInTheDocument();
+    await expect.element(screen.getByText("地域")).toBeInTheDocument();
   });
 
-  it("選択された値を正しく表示する", () => {
-    renderWithProviders(
+  it("選択された値を正しく表示する", async () => {
+    await renderWithProviders(
       <Select label="地域" value="tokyo" onChange={vi.fn()} selectOptions={selectOptions} />
     );
 
-    const select = screen.getByRole("combobox", { name: "地域" }) as HTMLSelectElement;
-    expect(select.value).toBe("tokyo");
+    const select = screen.getByRole("combobox", { name: "地域" });
+    await expect.element(select).toHaveValue("tokyo");
   });
 
-  it("すべてのオプションが存在する", () => {
-    renderWithProviders(
+  it("すべてのオプションが存在する", async () => {
+    await renderWithProviders(
       <Select label="地域" value="tokyo" onChange={vi.fn()} selectOptions={selectOptions} />
     );
 
-    const options = screen.getAllByRole("option");
+    const options = screen.getByRole("option").all();
     expect(options).toHaveLength(3);
   });
 
   it("オプション選択時にonChangeが呼ばれる", async () => {
     const handleChange = vi.fn();
-    const { user } = renderWithProviders(
+    const { user } = await renderWithProviders(
       <Select label="地域" value="tokyo" onChange={handleChange} selectOptions={selectOptions} />
     );
 
@@ -48,12 +48,12 @@ describe("Select Component", () => {
     expect(handleChange).toHaveBeenCalled();
   });
 
-  it("適切なaria-label属性を持つ", () => {
-    renderWithProviders(
+  it("適切なaria-label属性を持つ", async () => {
+    await renderWithProviders(
       <Select label="地域" value="tokyo" onChange={vi.fn()} selectOptions={selectOptions} />
     );
 
     const select = screen.getByRole("combobox", { name: "地域" });
-    expect(select).toBeInTheDocument();
+    await expect.element(select).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/SettingsMenu/SettingsMenu.test.tsx
+++ b/packages/viewer/components/SettingsMenu/SettingsMenu.test.tsx
@@ -12,91 +12,98 @@ const renderSettingsMenu = (auth0Config = {}) =>
   );
 
 describe("SettingsMenu", () => {
-  it("歯車ボタンが常にレンダリングされる", () => {
-    renderSettingsMenu();
+  it("歯車ボタンが常にレンダリングされる", async () => {
+    await renderSettingsMenu();
 
-    expect(screen.getByRole("button", { name: "設定" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "設定" })).toBeInTheDocument();
   });
 
-  it("isLoading中でも歯車ボタンが表示される", () => {
-    renderSettingsMenu({ isLoading: true });
+  it("isLoading中でも歯車ボタンが表示される", async () => {
+    await renderSettingsMenu({ isLoading: true });
 
-    expect(screen.getByRole("button", { name: "設定" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("button", { name: "設定" })).toBeInTheDocument();
   });
 
   it("クリックでメニューが開く", async () => {
-    const { user } = renderSettingsMenu();
+    const { user } = await renderSettingsMenu();
 
     await user.click(screen.getByRole("button", { name: "設定" }));
 
-    expect(screen.getByRole("menu", { name: "設定メニュー" })).toBeInTheDocument();
+    await expect.element(screen.getByRole("menu", { name: "設定メニュー" })).toBeInTheDocument();
   });
 
   it("再クリックでメニューが閉じる", async () => {
-    const { user } = renderSettingsMenu();
+    const { user } = await renderSettingsMenu();
 
     await user.click(screen.getByRole("button", { name: "設定" }));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await expect.element(screen.getByRole("menu")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "設定" }));
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await expect.element(screen.getByRole("menu")).not.toBeInTheDocument();
   });
 
   it("Escapeキーでメニューが閉じる", async () => {
-    const { user } = renderSettingsMenu();
+    const { user } = await renderSettingsMenu();
 
     await user.click(screen.getByRole("button", { name: "設定" }));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    await expect.element(screen.getByRole("menu")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await expect.element(screen.getByRole("menu")).not.toBeInTheDocument();
   });
 
   describe("カラーモード", () => {
     it("3つのモード選択肢が表示される", async () => {
-      const { user } = renderSettingsMenu();
+      const { user } = await renderSettingsMenu();
 
       await user.click(screen.getByRole("button", { name: "設定" }));
 
-      expect(screen.getByRole("menuitemradio", { name: "システム設定" })).toBeInTheDocument();
-      expect(screen.getByRole("menuitemradio", { name: "ライト" })).toBeInTheDocument();
-      expect(screen.getByRole("menuitemradio", { name: "ダーク" })).toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("menuitemradio", { name: "システム設定" }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("menuitemradio", { name: "ライト" }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("menuitemradio", { name: "ダーク" }))
+        .toBeInTheDocument();
     });
 
     it("デフォルトでシステム設定がアクティブ", async () => {
-      const { user } = renderSettingsMenu();
+      const { user } = await renderSettingsMenu();
 
       await user.click(screen.getByRole("button", { name: "設定" }));
 
-      expect(screen.getByRole("menuitemradio", { name: "システム設定" })).toHaveAttribute(
-        "aria-checked",
-        "true"
-      );
+      await expect
+        .element(screen.getByRole("menuitemradio", { name: "システム設定" }))
+        .toHaveAttribute("aria-checked", "true");
     });
   });
 
   describe("ログイン/ログアウト", () => {
     it("isLoading中は無効化される", async () => {
-      const { user } = renderSettingsMenu({ isLoading: true });
+      const { user } = await renderSettingsMenu({ isLoading: true });
 
       await user.click(screen.getByRole("button", { name: "設定" }));
 
       const authItem = screen.getByRole("menuitem", { name: "読み込み中..." });
-      expect(authItem).toBeDisabled();
-      expect(authItem).toHaveTextContent("読み込み中...");
+      await expect.element(authItem).toBeDisabled();
+      await expect.element(authItem).toHaveTextContent("読み込み中...");
     });
 
     it("tokenありの場合はログアウトを表示する", async () => {
-      const { user } = renderSettingsMenu({ token: "some-token" });
+      const { user } = await renderSettingsMenu({ token: "some-token" });
 
       await user.click(screen.getByRole("button", { name: "設定" }));
 
-      expect(screen.getByRole("menuitem", { name: "ログアウト" })).toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("menuitem", { name: "ログアウト" }))
+        .toBeInTheDocument();
     });
 
     it("ログアウトをクリックするとlogoutが呼ばれる", async () => {
       const logout = vi.fn();
-      const { user } = renderSettingsMenu({ token: "some-token", logout });
+      const { user } = await renderSettingsMenu({ token: "some-token", logout });
 
       await user.click(screen.getByRole("button", { name: "設定" }));
       await user.click(screen.getByRole("menuitem", { name: "ログアウト" }));
@@ -108,16 +115,16 @@ describe("SettingsMenu", () => {
     });
 
     it("tokenなしの場合はログインを表示する", async () => {
-      const { user } = renderSettingsMenu({ token: "" });
+      const { user } = await renderSettingsMenu({ token: "" });
 
       await user.click(screen.getByRole("button", { name: "設定" }));
 
-      expect(screen.getByRole("menuitem")).toHaveTextContent("ログイン");
+      await expect.element(screen.getByRole("menuitem")).toHaveTextContent("ログイン");
     });
 
     it("ログインをクリックするとloginが呼ばれる", async () => {
       const login = vi.fn();
-      const { user } = renderSettingsMenu({ token: "", login });
+      const { user } = await renderSettingsMenu({ token: "", login });
 
       await user.click(screen.getByRole("button", { name: "設定" }));
       await user.click(screen.getByRole("menuitem"));

--- a/packages/viewer/components/Skeleton/Skeleton.test.tsx
+++ b/packages/viewer/components/Skeleton/Skeleton.test.tsx
@@ -3,9 +3,9 @@ import { renderWithProviders } from "../../test/utils/test-utils";
 import { Skeleton } from "./Skeleton";
 
 describe("Skeleton", () => {
-  it("正しくレンダリングされる", () => {
-    const { container } = renderWithProviders(<Skeleton width={200} height={20} />);
-    const skeleton = container.querySelector('[data-testid="skeleton"]');
-    expect(skeleton).toBeInTheDocument();
+  it("正しくレンダリングされる", async () => {
+    const { container } = await renderWithProviders(<Skeleton width={200} height={20} />);
+    const skeleton = container.querySelector<HTMLElement>('[data-testid="skeleton"]');
+    await expect.element(skeleton!).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Snackbar/Snackbar.test.tsx
+++ b/packages/viewer/components/Snackbar/Snackbar.test.tsx
@@ -3,28 +3,30 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { Snackbar } from "./Snackbar";
 
 describe("Snackbar Component", () => {
-  it("open=trueの場合にメッセージを表示する", () => {
-    renderWithProviders(<Snackbar open={true} message="保存しました" />);
+  it("open=trueの場合にメッセージを表示する", async () => {
+    await renderWithProviders(<Snackbar open={true} message="保存しました" />);
 
-    expect(screen.getByText("保存しました")).toBeInTheDocument();
+    await expect.element(screen.getByText("保存しました")).toBeInTheDocument();
   });
 
-  it("open=falseの場合にメッセージを表示しない", () => {
-    renderWithProviders(<Snackbar open={false} message="非表示メッセージ" />);
+  it("open=falseの場合にメッセージを表示しない", async () => {
+    await renderWithProviders(<Snackbar open={false} message="非表示メッセージ" />);
 
-    expect(screen.queryByText("非表示メッセージ")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("非表示メッセージ")).not.toBeInTheDocument();
   });
 
-  it("onCloseコールバックを受け取る", () => {
+  it("onCloseコールバックを受け取る", async () => {
     const onClose = vi.fn();
-    renderWithProviders(<Snackbar open={true} message="テスト" onClose={onClose} />);
+    await renderWithProviders(<Snackbar open={true} message="テスト" onClose={onClose} />);
 
-    expect(screen.getByText("テスト")).toBeInTheDocument();
+    await expect.element(screen.getByText("テスト")).toBeInTheDocument();
   });
 
-  it("autoHideDurationプロパティを受け取る", () => {
-    renderWithProviders(<Snackbar open={true} message="自動非表示" autoHideDuration={3000} />);
+  it("autoHideDurationプロパティを受け取る", async () => {
+    await renderWithProviders(
+      <Snackbar open={true} message="自動非表示" autoHideDuration={3000} />
+    );
 
-    expect(screen.getByText("自動非表示")).toBeInTheDocument();
+    await expect.element(screen.getByText("自動非表示")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Spacer/Spacer.test.tsx
+++ b/packages/viewer/components/Spacer/Spacer.test.tsx
@@ -3,16 +3,16 @@ import { renderWithProviders } from "../../test/utils/test-utils";
 import { Spacer } from "./Spacer";
 
 describe("Spacer", () => {
-  it("vertical方向ではwidth=1、height=sizeになる", () => {
-    renderWithProviders(<Spacer size={20} axis="vertical" data-testid="spacer" />);
+  it("vertical方向ではwidth=1、height=sizeになる", async () => {
+    await renderWithProviders(<Spacer size={20} axis="vertical" data-testid="spacer" />);
     const spacer = document.querySelector("span");
     expect(spacer).toBeDefined();
     expect(spacer!.style.width).toBe("1px");
     expect(spacer!.style.height).toBe("20px");
   });
 
-  it("horizontal方向ではwidth=size、height=1になる", () => {
-    renderWithProviders(<Spacer size={30} axis="horizontal" />);
+  it("horizontal方向ではwidth=size、height=1になる", async () => {
+    await renderWithProviders(<Spacer size={30} axis="horizontal" />);
     const spacer = document.querySelector("span");
     expect(spacer).toBeDefined();
     expect(spacer!.style.width).toBe("30px");

--- a/packages/viewer/components/Spinner/Spinner.test.tsx
+++ b/packages/viewer/components/Spinner/Spinner.test.tsx
@@ -3,24 +3,24 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { Spinner } from "./Spinner";
 
 describe("Spinner Component", () => {
-  it("正しくレンダリングされる", () => {
-    renderWithProviders(<Spinner />);
+  it("正しくレンダリングされる", async () => {
+    await renderWithProviders(<Spinner />);
 
     const spinner = screen.getByRole("progressbar");
-    expect(spinner).toBeInTheDocument();
+    await expect.element(spinner).toBeInTheDocument();
   });
 
-  it("適切なaria-label属性を持つ", () => {
-    renderWithProviders(<Spinner />);
+  it("適切なaria-label属性を持つ", async () => {
+    await renderWithProviders(<Spinner />);
 
     const spinner = screen.getByRole("progressbar");
-    expect(spinner).toHaveAttribute("aria-label", "読み込み中");
+    await expect.element(spinner).toHaveAttribute("aria-label", "読み込み中");
   });
 
-  it("sizeプロパティを受け取れる", () => {
-    renderWithProviders(<Spinner size={60} />);
+  it("sizeプロパティを受け取れる", async () => {
+    await renderWithProviders(<Spinner size={60} />);
 
     const spinner = screen.getByRole("progressbar");
-    expect(spinner).toBeInTheDocument();
+    await expect.element(spinner).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Tab/Tab.test.tsx
+++ b/packages/viewer/components/Tab/Tab.test.tsx
@@ -3,17 +3,17 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { Tab } from "./Tab";
 
 describe("Tab", () => {
-  it("正しいa11y属性を持つ", () => {
-    renderWithProviders(<Tab label="予約" value="reservation" />);
+  it("正しいa11y属性を持つ", async () => {
+    await renderWithProviders(<Tab label="予約" value="reservation" />);
     const tab = screen.getByRole("tab", { name: "予約" });
-    expect(tab).toHaveAttribute("id", "tab-reservation");
-    expect(tab).toHaveAttribute("aria-controls", "tabpanel-reservation");
-    expect(tab).toHaveAttribute("tabindex", "0");
+    await expect.element(tab).toHaveAttribute("id", "tab-reservation");
+    await expect.element(tab).toHaveAttribute("aria-controls", "tabpanel-reservation");
+    await expect.element(tab).toHaveAttribute("tabindex", "0");
   });
 
-  it("minWidthが0pxに設定される", () => {
-    renderWithProviders(<Tab label="施設" value="institution" />);
+  it("minWidthが0pxに設定される", async () => {
+    await renderWithProviders(<Tab label="施設" value="institution" />);
     const tab = screen.getByRole("tab", { name: "施設" });
-    expect(tab.style.minWidth).toBe("0px");
+    expect(tab.element().style.minWidth).toBe("0px");
   });
 });

--- a/packages/viewer/components/TabGroup/TabGroup.test.tsx
+++ b/packages/viewer/components/TabGroup/TabGroup.test.tsx
@@ -4,8 +4,8 @@ import { Tab } from "../Tab";
 import { TabGroup, TabPanel } from "./TabGroup";
 
 describe("TabGroup Component", () => {
-  it("タブを表示する", () => {
-    renderWithProviders(
+  it("タブを表示する", async () => {
+    await renderWithProviders(
       <TabGroup value="tab1">
         <Tab label="タブ1" value="tab1" />
         <Tab label="タブ2" value="tab2" />
@@ -13,62 +13,63 @@ describe("TabGroup Component", () => {
       </TabGroup>
     );
 
-    expect(screen.getByRole("tablist")).toBeInTheDocument();
-    expect(screen.getByText("タブ1")).toBeInTheDocument();
-    expect(screen.getByText("タブ2")).toBeInTheDocument();
-    expect(screen.getByText("タブ3")).toBeInTheDocument();
+    await expect.element(screen.getByRole("tablist")).toBeInTheDocument();
+    await expect.element(screen.getByText("タブ1")).toBeInTheDocument();
+    await expect.element(screen.getByText("タブ2")).toBeInTheDocument();
+    await expect.element(screen.getByText("タブ3")).toBeInTheDocument();
   });
 
-  it("正しい数のタブを表示する", () => {
-    renderWithProviders(
+  it("正しい数のタブを表示する", async () => {
+    await renderWithProviders(
       <TabGroup value="tab1">
         <Tab label="タブA" value="tab1" />
         <Tab label="タブB" value="tab2" />
       </TabGroup>
     );
 
-    const tabs = screen.getAllByRole("tab");
+    await expect.element(screen.getByRole("tab").first()).toBeInTheDocument();
+    const tabs = screen.getByRole("tab").all();
     expect(tabs).toHaveLength(2);
   });
 
-  it("選択されたタブにaria-selected属性を持つ", () => {
-    renderWithProviders(
+  it("選択されたタブにaria-selected属性を持つ", async () => {
+    await renderWithProviders(
       <TabGroup value="tab2">
         <Tab label="タブ1" value="tab1" />
         <Tab label="タブ2" value="tab2" />
       </TabGroup>
     );
 
-    const tab1 = screen.getByText("タブ1").closest('[role="tab"]');
-    const tab2 = screen.getByText("タブ2").closest('[role="tab"]');
-    expect(tab1).toHaveAttribute("aria-selected", "false");
-    expect(tab2).toHaveAttribute("aria-selected", "true");
+    const tab1 = screen.getByText("タブ1").element().closest<HTMLElement>('[role="tab"]');
+    const tab2 = screen.getByText("タブ2").element().closest<HTMLElement>('[role="tab"]');
+    await expect.element(tab1!).toHaveAttribute("aria-selected", "false");
+    await expect.element(tab2!).toHaveAttribute("aria-selected", "true");
   });
 });
 
 describe("TabPanel Component", () => {
-  it("currentValueがtabValueと一致する場合にコンテンツを表示する", () => {
-    renderWithProviders(
+  it("currentValueがtabValueと一致する場合にコンテンツを表示する", async () => {
+    await renderWithProviders(
       <TabPanel tabValue="tab1" currentValue="tab1">
         <div>パネルの内容</div>
       </TabPanel>
     );
 
-    expect(screen.getByText("パネルの内容")).toBeInTheDocument();
+    await expect.element(screen.getByText("パネルの内容")).toBeInTheDocument();
   });
 
-  it("currentValueがtabValueと一致しない場合にnullを返す", () => {
-    renderWithProviders(
+  it("currentValueがtabValueと一致しない場合にnullを返す", async () => {
+    await renderWithProviders(
       <TabPanel tabValue="tab1" currentValue="tab2">
         <div>非表示の内容</div>
       </TabPanel>
     );
 
-    expect(screen.queryByText("非表示の内容")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("非表示の内容")).not.toBeInTheDocument();
   });
 
-  it("異なるtabValueで別々のパネルを切り替える", () => {
-    renderWithProviders(
+  it("異なるtabValueで別々のパネルを切り替える", async () => {
+    await renderWithProviders(
       <>
         <TabPanel tabValue="tab1" currentValue="tab1">
           <div>パネル1の内容</div>
@@ -79,7 +80,7 @@ describe("TabPanel Component", () => {
       </>
     );
 
-    expect(screen.getByText("パネル1の内容")).toBeInTheDocument();
-    expect(screen.queryByText("パネル2の内容")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("パネル1の内容")).toBeInTheDocument();
+    await expect.element(screen.getByText("パネル2の内容")).not.toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/Table/Table.test.tsx
+++ b/packages/viewer/components/Table/Table.test.tsx
@@ -3,8 +3,8 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "./Table";
 
 describe("Table components", () => {
-  it("テーブルが正しくレンダリングされる", () => {
-    renderWithProviders(
+  it("テーブルが正しくレンダリングされる", async () => {
+    await renderWithProviders(
       <TableContainer>
         <Table>
           <TableHead>
@@ -21,8 +21,8 @@ describe("Table components", () => {
       </TableContainer>
     );
 
-    expect(screen.getByRole("table")).toBeInTheDocument();
-    expect(screen.getByText("ヘッダー")).toBeInTheDocument();
-    expect(screen.getByText("データ")).toBeInTheDocument();
+    await expect.element(screen.getByRole("table")).toBeInTheDocument();
+    await expect.element(screen.getByText("ヘッダー")).toBeInTheDocument();
+    await expect.element(screen.getByText("データ")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/utils/AuthGuard.test.tsx
+++ b/packages/viewer/components/utils/AuthGuard.test.tsx
@@ -3,20 +3,20 @@ import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { AuthGuard } from "./AuthGuard";
 
 describe("AuthGuard Component", () => {
-  it("anonymous=trueかつisLoading=trueの場合にローディングを表示する", () => {
-    renderWithProviders(<AuthGuard Component={<div>保護されたページ</div>} />, {
+  it("anonymous=trueかつisLoading=trueの場合にローディングを表示する", async () => {
+    await renderWithProviders(<AuthGuard Component={<div>保護されたページ</div>} />, {
       auth0Config: {
         isLoading: true,
         userInfo: { anonymous: true, trial: false },
       },
     });
 
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
-    expect(screen.queryByText("保護されたページ")).not.toBeInTheDocument();
+    await expect.element(screen.getByRole("progressbar")).toBeInTheDocument();
+    await expect.element(screen.getByText("保護されたページ")).not.toBeInTheDocument();
   });
 
-  it("anonymous=trueかつisLoading=falseの場合にトップページへリダイレクトする", () => {
-    renderWithProviders(<AuthGuard Component={<div>保護されたページ</div>} />, {
+  it("anonymous=trueかつisLoading=falseの場合にトップページへリダイレクトする", async () => {
+    await renderWithProviders(<AuthGuard Component={<div>保護されたページ</div>} />, {
       initialEntries: ["/protected"],
       route: "/protected",
       auth0Config: {
@@ -25,17 +25,17 @@ describe("AuthGuard Component", () => {
       },
     });
 
-    expect(screen.queryByText("保護されたページ")).not.toBeInTheDocument();
+    await expect.element(screen.getByText("保護されたページ")).not.toBeInTheDocument();
   });
 
-  it("anonymous=falseの場合にラップされたComponentをレンダリングする", () => {
-    renderWithProviders(<AuthGuard Component={<div>保護されたページ</div>} />, {
+  it("anonymous=falseの場合にラップされたComponentをレンダリングする", async () => {
+    await renderWithProviders(<AuthGuard Component={<div>保護されたページ</div>} />, {
       auth0Config: {
         isLoading: false,
         userInfo: { anonymous: false, trial: false },
       },
     });
 
-    expect(screen.getByText("保護されたページ")).toBeInTheDocument();
+    await expect.element(screen.getByText("保護されたページ")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/utils/ErrorBoundary.test.tsx
+++ b/packages/viewer/components/utils/ErrorBoundary.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderWithProviders, screen, waitFor } from "../../test/utils/test-utils";
+import { renderWithProviders, screen } from "../../test/utils/test-utils";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 const ThrowingChild = () => {
@@ -22,38 +22,40 @@ describe("ErrorBoundary Component", () => {
     consoleLogSpy.mockRestore();
   });
 
-  it("エラーがない場合に子コンポーネントを正常にレンダリングする", () => {
-    renderWithProviders(
+  it("エラーがない場合に子コンポーネントを正常にレンダリングする", async () => {
+    await renderWithProviders(
       <ErrorBoundary>
         <GoodChild />
       </ErrorBoundary>
     );
 
-    expect(screen.getByText("正常な子コンポーネント")).toBeInTheDocument();
+    await expect.element(screen.getByText("正常な子コンポーネント")).toBeInTheDocument();
   });
 
-  it("子コンポーネントがエラーをスローした場合にエラーSnackbarを表示する", () => {
-    renderWithProviders(
+  it("子コンポーネントがエラーをスローした場合にエラーSnackbarを表示する", async () => {
+    await renderWithProviders(
       <ErrorBoundary>
         <ThrowingChild />
       </ErrorBoundary>
     );
 
-    expect(
-      screen.getByText(
-        "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
+    await expect
+      .element(
+        screen.getByText(
+          "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
+        )
       )
-    ).toBeInTheDocument();
+      .toBeInTheDocument();
   });
 
   it("unhandledrejectionイベントでエラー表示する", async () => {
-    renderWithProviders(
+    await renderWithProviders(
       <ErrorBoundary>
         <div>正常</div>
       </ErrorBoundary>
     );
 
-    expect(screen.getByText("正常")).toBeInTheDocument();
+    await expect.element(screen.getByText("正常")).toBeInTheDocument();
 
     const rejectedPromise = Promise.reject(new Error("test rejection"));
     // Prevent actual unhandled rejection noise
@@ -66,12 +68,12 @@ describe("ErrorBoundary Component", () => {
       })
     );
 
-    await waitFor(() => {
-      expect(
+    await expect
+      .element(
         screen.getByText(
           "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
         )
-      ).toBeInTheDocument();
-    });
+      )
+      .toBeInTheDocument();
   });
 });

--- a/packages/viewer/components/utils/ScrollToTop.test.tsx
+++ b/packages/viewer/components/utils/ScrollToTop.test.tsx
@@ -3,10 +3,10 @@ import { renderWithProviders } from "../../test/utils/test-utils";
 import { ScrollToTop } from "./ScrollToTop";
 
 describe("ScrollToTop Component", () => {
-  it("マウント時にwindow.scrollTo(0, 0)を呼び出す", () => {
+  it("マウント時にwindow.scrollTo(0, 0)を呼び出す", async () => {
     const scrollToSpy = vi.spyOn(window, "scrollTo");
 
-    renderWithProviders(<ScrollToTop />);
+    await renderWithProviders(<ScrollToTop />);
 
     expect(scrollToSpy).toHaveBeenCalledWith(0, 0);
   });

--- a/packages/viewer/contexts/Auth0.test.tsx
+++ b/packages/viewer/contexts/Auth0.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
-import { userEvent } from "@vitest/browser/context";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { screen } from "../test/utils/test-utils";
 import { Auth0Client } from "@auth0/auth0-spa-js";
 import { Auth0Provider, useAuth0 } from "./Auth0";
 
@@ -75,43 +76,41 @@ describe("Auth0Provider", () => {
 
   describe("子コンポーネントのレンダリング", () => {
     it("子コンポーネントを正しくレンダリングする", async () => {
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <div data-testid="child">Hello</div>
         </Auth0Provider>
       );
 
-      expect(screen.getByTestId("child")).toBeInTheDocument();
-      expect(screen.getByTestId("child").textContent).toBe("Hello");
+      await expect.element(screen.getByTestId("child")).toBeInTheDocument();
+      expect(screen.getByTestId("child").element().textContent).toBe("Hello");
     });
   });
 
   describe("初期ローディング状態", () => {
-    it("初期状態でisLoadingがtrueである", () => {
+    it("初期状態でisLoadingがtrueである", async () => {
       // Configure checkSession to never resolve so we can observe initial loading state
       configureMockClient({
         checkSession: vi.fn().mockReturnValue(new Promise(() => {})),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      expect(screen.getByTestId("is-loading").textContent).toBe("true");
+      expect(screen.getByTestId("is-loading").element().textContent).toBe("true");
     });
 
     it("checkSession完了後にisLoadingがfalseになる", async () => {
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
     });
   });
 
@@ -119,15 +118,13 @@ describe("Auth0Provider", () => {
     it("マウント時にcheckSessionが呼ばれる", async () => {
       const methods = configureMockClient();
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(methods.checkSession).toHaveBeenCalled();
-      });
+      await vi.waitFor(() => expect(methods.checkSession).toHaveBeenCalled());
     });
   });
 
@@ -136,15 +133,13 @@ describe("Auth0Provider", () => {
       const methods = configureMockClient();
       window.history.pushState({}, "", "/waiting?code=test-code&state=test-state");
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(methods.handleRedirectCallback).toHaveBeenCalled();
-      });
+      await vi.waitFor(() => expect(methods.handleRedirectCallback).toHaveBeenCalled());
       expect(methods.checkSession).not.toHaveBeenCalled();
 
       window.history.pushState({}, "", "/");
@@ -154,15 +149,13 @@ describe("Auth0Provider", () => {
       const methods = configureMockClient();
       window.history.pushState({}, "", "/");
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(methods.checkSession).toHaveBeenCalled();
-      });
+      await vi.waitFor(() => expect(methods.checkSession).toHaveBeenCalled());
       expect(methods.handleRedirectCallback).not.toHaveBeenCalled();
     });
   });
@@ -176,15 +169,13 @@ describe("Auth0Provider", () => {
         }),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("token").textContent).toBe("test-token-123");
-      });
+      await expect.element(screen.getByTestId("token")).toHaveTextContent(/^test-token-123$/);
     });
 
     it("トークン取得後にuserInfoが正しくセットされる", async () => {
@@ -195,16 +186,14 @@ describe("Auth0Provider", () => {
         }),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("anonymous").textContent).toBe("false");
-        expect(screen.getByTestId("trial").textContent).toBe("true");
-      });
+      await expect.element(screen.getByTestId("anonymous")).toHaveTextContent(/^false$/);
+      await expect.element(screen.getByTestId("trial")).toHaveTextContent(/^true$/);
     });
 
     it("anonymousロールの場合、userInfo.anonymousがtrueになる", async () => {
@@ -215,16 +204,14 @@ describe("Auth0Provider", () => {
         }),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("anonymous").textContent).toBe("true");
-        expect(screen.getByTestId("trial").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("anonymous")).toHaveTextContent(/^true$/);
+      await expect.element(screen.getByTestId("trial")).toHaveTextContent(/^false$/);
     });
   });
 
@@ -232,23 +219,21 @@ describe("Auth0Provider", () => {
     it("loginがloginWithRedirectを呼び出す", async () => {
       const methods = configureMockClient();
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
 
-      await act(async () => {
-        await userEvent.click(screen.getByTestId("login-btn"));
-      });
+      await userEvent.click(screen.getByTestId("login-btn"));
 
-      expect(methods.loginWithRedirect).toHaveBeenCalledWith({
-        authorizationParams: { redirect_uri: "http://localhost" },
-      });
+      await vi.waitFor(() =>
+        expect(methods.loginWithRedirect).toHaveBeenCalledWith({
+          authorizationParams: { redirect_uri: "http://localhost" },
+        })
+      );
     });
   });
 
@@ -256,21 +241,17 @@ describe("Auth0Provider", () => {
     it("logoutがauth0Client.logoutを呼び出す", async () => {
       const methods = configureMockClient();
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
 
-      await act(async () => {
-        await userEvent.click(screen.getByTestId("logout-btn"));
-      });
+      await userEvent.click(screen.getByTestId("logout-btn"));
 
-      expect(methods.logout).toHaveBeenCalledWith({ logoutParams: {} });
+      await vi.waitFor(() => expect(methods.logout).toHaveBeenCalledWith({ logoutParams: {} }));
     });
   });
 
@@ -280,15 +261,13 @@ describe("Auth0Provider", () => {
         checkSession: vi.fn().mockRejectedValue(new Error("Session check failed")),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
     });
 
     it("checkSessionが失敗した場合、トークンは空のままである", async () => {
@@ -296,18 +275,16 @@ describe("Auth0Provider", () => {
         checkSession: vi.fn().mockRejectedValue(new Error("Session check failed")),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
 
       // Token should remain empty since checkSession failed before getTokenSilently
-      expect(screen.getByTestId("token").textContent).toBe("");
+      expect(screen.getByTestId("token").element().textContent).toBe("");
     });
 
     it("getTokenSilentlyが失敗した場合、トークンは空のままである", async () => {
@@ -315,17 +292,15 @@ describe("Auth0Provider", () => {
         getTokenSilently: vi.fn().mockRejectedValue(new Error("Token fetch failed")),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
 
-      expect(screen.getByTestId("token").textContent).toBe("");
+      expect(screen.getByTestId("token").element().textContent).toBe("");
     });
   });
 
@@ -335,71 +310,65 @@ describe("Auth0Provider", () => {
         getTokenSilently: vi.fn().mockResolvedValue(""),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId("is-loading").textContent).toBe("false");
-      });
+      await expect.element(screen.getByTestId("is-loading")).toHaveTextContent(/^false$/);
 
       // Token should remain empty because getTokenSilently returned falsy
-      expect(screen.getByTestId("token").textContent).toBe("");
+      expect(screen.getByTestId("token").element().textContent).toBe("");
     });
   });
 
   describe("デフォルトコンテキスト", () => {
     it("Auth0Providerの外でuseAuth0を使用するとデフォルトのlogin/logoutが呼べる", async () => {
-      render(<Auth0Consumer />);
+      await render(<Auth0Consumer />);
 
-      expect(screen.getByTestId("is-loading").textContent).toBe("true");
-      expect(screen.getByTestId("token").textContent).toBe("");
+      expect(screen.getByTestId("is-loading").element().textContent).toBe("true");
+      expect(screen.getByTestId("token").element().textContent).toBe("");
 
       // Default login and logout (from initialContext) should not throw when called
-      await act(async () => {
-        await userEvent.click(screen.getByTestId("login-btn"));
-      });
-      await act(async () => {
-        await userEvent.click(screen.getByTestId("logout-btn"));
-      });
+      await userEvent.click(screen.getByTestId("login-btn"));
+      await userEvent.click(screen.getByTestId("logout-btn"));
 
       // Should still be in initial state (no crash)
-      expect(screen.getByTestId("is-loading").textContent).toBe("true");
+      expect(screen.getByTestId("is-loading").element().textContent).toBe("true");
     });
   });
 
   describe("初期コンテキスト値", () => {
-    it("初期状態のトークンは空文字列である", () => {
+    it("初期状態のトークンは空文字列である", async () => {
       // Configure checkSession to never resolve so we can observe initial state
       configureMockClient({
         checkSession: vi.fn().mockReturnValue(new Promise(() => {})),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      expect(screen.getByTestId("token").textContent).toBe("");
+      expect(screen.getByTestId("token").element().textContent).toBe("");
     });
 
-    it("初期状態のuserInfoはanonymous=true, trial=falseである", () => {
+    it("初期状態のuserInfoはanonymous=true, trial=falseである", async () => {
       // Configure checkSession to never resolve so we can observe initial state
       configureMockClient({
         checkSession: vi.fn().mockReturnValue(new Promise(() => {})),
       });
 
-      render(
+      await render(
         <Auth0Provider {...defaultProviderProps}>
           <Auth0Consumer />
         </Auth0Provider>
       );
 
-      expect(screen.getByTestId("anonymous").textContent).toBe("true");
-      expect(screen.getByTestId("trial").textContent).toBe("false");
+      expect(screen.getByTestId("anonymous").element().textContent).toBe("true");
+      expect(screen.getByTestId("trial").element().textContent).toBe("false");
     });
   });
 });

--- a/packages/viewer/contexts/ColorMode.test.tsx
+++ b/packages/viewer/contexts/ColorMode.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
-import { userEvent } from "@vitest/browser/context";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { screen } from "../test/utils/test-utils";
 import { ColorModeProvider, useColorMode } from "./ColorMode";
 
 const STORAGE_KEY = "shisetsu-viewer-color-mode";
@@ -25,31 +26,31 @@ describe("ColorModeProvider", () => {
   });
 
   describe("デフォルト状態", () => {
-    it("デフォルトモードは'system'である", () => {
-      render(
+    it("デフォルトモードは'system'である", async () => {
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("mode").textContent).toBe("system");
+      expect(screen.getByTestId("mode").element().textContent).toBe("system");
     });
 
-    it("子コンポーネントを正しくレンダリングする", () => {
-      render(
+    it("子コンポーネントを正しくレンダリングする", async () => {
+      await render(
         <ColorModeProvider>
           <div data-testid="child">Hello</div>
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("child")).toBeInTheDocument();
-      expect(screen.getByTestId("child").textContent).toBe("Hello");
+      await expect.element(screen.getByTestId("child")).toBeInTheDocument();
+      expect(screen.getByTestId("child").element().textContent).toBe("Hello");
     });
   });
 
   describe("toggleMode", () => {
     it("system -> light -> dark -> system の順にモードが切り替わる", async () => {
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
@@ -58,31 +59,25 @@ describe("ColorModeProvider", () => {
       const toggleButton = screen.getByTestId("toggle");
 
       // Initial: system
-      expect(screen.getByTestId("mode").textContent).toBe("system");
+      expect(screen.getByTestId("mode").element().textContent).toBe("system");
 
       // system -> light
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
-      expect(screen.getByTestId("mode").textContent).toBe("light");
+      await userEvent.click(toggleButton);
+      await expect.element(screen.getByTestId("mode")).toHaveTextContent(/^light$/);
 
       // light -> dark
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
-      expect(screen.getByTestId("mode").textContent).toBe("dark");
+      await userEvent.click(toggleButton);
+      await expect.element(screen.getByTestId("mode")).toHaveTextContent(/^dark$/);
 
       // dark -> system
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
-      expect(screen.getByTestId("mode").textContent).toBe("system");
+      await userEvent.click(toggleButton);
+      await expect.element(screen.getByTestId("mode")).toHaveTextContent(/^system$/);
     });
   });
 
   describe("localStorage永続化", () => {
     it("toggleModeでlocalStorageにモードを保存する", async () => {
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
@@ -91,118 +86,110 @@ describe("ColorModeProvider", () => {
       const toggleButton = screen.getByTestId("toggle");
 
       // Toggle to light
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
-      expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+      await userEvent.click(toggleButton);
+      await vi.waitFor(() => expect(localStorage.getItem(STORAGE_KEY)).toBe("light"));
 
       // Toggle to dark
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
-      expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+      await userEvent.click(toggleButton);
+      await vi.waitFor(() => expect(localStorage.getItem(STORAGE_KEY)).toBe("dark"));
 
       // Toggle back to system
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
-      expect(localStorage.getItem(STORAGE_KEY)).toBe("system");
+      await userEvent.click(toggleButton);
+      await vi.waitFor(() => expect(localStorage.getItem(STORAGE_KEY)).toBe("system"));
     });
 
-    it("localStorageから初期モードを読み込む", () => {
+    it("localStorageから初期モードを読み込む", async () => {
       localStorage.setItem(STORAGE_KEY, "dark");
 
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("mode").textContent).toBe("dark");
+      expect(screen.getByTestId("mode").element().textContent).toBe("dark");
     });
 
-    it("localStorageにlightが保存されている場合、lightで初期化される", () => {
+    it("localStorageにlightが保存されている場合、lightで初期化される", async () => {
       localStorage.setItem(STORAGE_KEY, "light");
 
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("mode").textContent).toBe("light");
+      expect(screen.getByTestId("mode").element().textContent).toBe("light");
     });
 
-    it("localStorageに無効な値がある場合、systemにフォールバックする", () => {
+    it("localStorageに無効な値がある場合、systemにフォールバックする", async () => {
       localStorage.setItem(STORAGE_KEY, "invalid-mode");
 
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("mode").textContent).toBe("system");
+      expect(screen.getByTestId("mode").element().textContent).toBe("system");
     });
   });
 
   describe("テーマ解決", () => {
-    it("systemモードでprefers-color-schemeがlightの場合、isDark=false", () => {
+    it("systemモードでprefers-color-schemeがlightの場合、isDark=false", async () => {
       // Default matchMedia returns matches=false (light)
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("is-dark").textContent).toBe("light");
+      expect(screen.getByTestId("is-dark").element().textContent).toBe("light");
     });
 
-    it("lightモードではシステム設定に関係なくisDark=false", () => {
+    it("lightモードではシステム設定に関係なくisDark=false", async () => {
       localStorage.setItem(STORAGE_KEY, "light");
 
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("mode").textContent).toBe("light");
-      expect(screen.getByTestId("is-dark").textContent).toBe("light");
+      expect(screen.getByTestId("mode").element().textContent).toBe("light");
+      expect(screen.getByTestId("is-dark").element().textContent).toBe("light");
     });
 
-    it("darkモードではシステム設定に関係なくisDark=true", () => {
+    it("darkモードではシステム設定に関係なくisDark=true", async () => {
       localStorage.setItem(STORAGE_KEY, "dark");
 
-      render(
+      await render(
         <ColorModeProvider>
           <ColorModeConsumer />
         </ColorModeProvider>
       );
 
-      expect(screen.getByTestId("mode").textContent).toBe("dark");
-      expect(screen.getByTestId("is-dark").textContent).toBe("dark");
+      expect(screen.getByTestId("mode").element().textContent).toBe("dark");
+      expect(screen.getByTestId("is-dark").element().textContent).toBe("dark");
     });
   });
 
   describe("useColorModeフック", () => {
-    it("プロバイダーなしではデフォルト値を返す", () => {
+    it("プロバイダーなしではデフォルト値を返す", async () => {
       // Context default: mode "system", isDark false
-      render(<ColorModeConsumer />);
+      await render(<ColorModeConsumer />);
 
-      expect(screen.getByTestId("mode").textContent).toBe("system");
+      expect(screen.getByTestId("mode").element().textContent).toBe("system");
     });
 
     it("プロバイダーなしでtoggleModeを呼んでもエラーにならない", async () => {
-      render(<ColorModeConsumer />);
+      await render(<ColorModeConsumer />);
 
       const toggleButton = screen.getByTestId("toggle");
-      await act(async () => {
-        await userEvent.click(toggleButton);
-      });
+      await userEvent.click(toggleButton);
 
       // Default toggleMode is a no-op, mode should remain "system"
-      expect(screen.getByTestId("mode").textContent).toBe("system");
+      expect(screen.getByTestId("mode").element().textContent).toBe("system");
     });
   });
 });

--- a/packages/viewer/hooks/useGraphQLQuery.test.tsx
+++ b/packages/viewer/hooks/useGraphQLQuery.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { worker } from "../test/mocks/browser";
-import { renderWithProviders, screen, waitFor } from "../test/utils/test-utils";
+import { renderWithProviders, screen } from "../test/utils/test-utils";
 import { useGraphQLQuery } from "./useGraphQLQuery";
 
 const TEST_ENDPOINT = import.meta.env.VITE_GRAPHQL_ENDPOINT;
@@ -39,9 +39,9 @@ describe("useGraphQLQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent query={QUERY} variables={{}} />);
+    await renderWithProviders(<TestComponent query={QUERY} variables={{}} />);
 
-    expect(screen.getByText("loading")).toBeInTheDocument();
+    await expect.element(screen.getByText("loading")).toBeInTheDocument();
   });
 
   it("フェッチ成功後にdataを返す", async () => {
@@ -53,11 +53,9 @@ describe("useGraphQLQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent query={QUERY} variables={{}} />);
+    await renderWithProviders(<TestComponent query={QUERY} variables={{}} />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Item A")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item A")).toBeInTheDocument();
   });
 
   it("Auth0ロード中はクエリを実行しない", async () => {
@@ -69,12 +67,12 @@ describe("useGraphQLQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent query={QUERY} variables={{}} />, {
+    await renderWithProviders(<TestComponent query={QUERY} variables={{}} />, {
       auth0Config: { isLoading: true, token: "" },
     });
 
-    expect(screen.getByText("loading")).toBeInTheDocument();
-    await waitFor(() => {
+    await expect.element(screen.getByText("loading")).toBeInTheDocument();
+    await vi.waitFor(() => {
       expect(requestCount).toBe(0);
     });
   });
@@ -88,10 +86,8 @@ describe("useGraphQLQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent query={QUERY} variables={{}} />);
+    await renderWithProviders(<TestComponent query={QUERY} variables={{}} />);
 
-    await waitFor(() => {
-      expect(screen.getByText("error: Something went wrong")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("error: Something went wrong")).toBeInTheDocument();
   });
 });

--- a/packages/viewer/hooks/useInfiniteScroll.test.ts
+++ b/packages/viewer/hooks/useInfiniteScroll.test.ts
@@ -1,30 +1,30 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook } from "vitest-browser-react";
 import { describe, expect, test, vi } from "vitest";
 import { useInfiniteScroll } from "./useInfiniteScroll";
 
 describe("useInfiniteScroll", () => {
-  test("行数が50以上なら末尾から50番目に sentinel を置く", () => {
-    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 100));
+  test("行数が50以上なら末尾から50番目に sentinel を置く", async () => {
+    const { result } = await renderHook(() => useInfiniteScroll(vi.fn(), 100));
     expect(result.current.sentinelIndex).toBe(50);
   });
 
-  test("行数がちょうど50なら sentinelIndex は 0", () => {
-    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 50));
+  test("行数がちょうど50なら sentinelIndex は 0", async () => {
+    const { result } = await renderHook(() => useInfiniteScroll(vi.fn(), 50));
     expect(result.current.sentinelIndex).toBe(0);
   });
 
-  test("行数が50未満でも sentinelIndex は負値にならず 0 にクランプされる", () => {
-    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 5));
+  test("行数が50未満でも sentinelIndex は負値にならず 0 にクランプされる", async () => {
+    const { result } = await renderHook(() => useInfiniteScroll(vi.fn(), 5));
     expect(result.current.sentinelIndex).toBe(0);
   });
 
-  test("行数が0でも sentinelIndex は 0", () => {
-    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 0));
+  test("行数が0でも sentinelIndex は 0", async () => {
+    const { result } = await renderHook(() => useInfiniteScroll(vi.fn(), 0));
     expect(result.current.sentinelIndex).toBe(0);
   });
 
-  test("sentinelRef はコールバック ref（関数）", () => {
-    const { result } = renderHook(() => useInfiniteScroll(vi.fn(), 10));
+  test("sentinelRef はコールバック ref（関数）", async () => {
+    const { result } = await renderHook(() => useInfiniteScroll(vi.fn(), 10));
     expect(typeof result.current.sentinelRef).toBe("function");
   });
 });

--- a/packages/viewer/hooks/useIsMobile.test.tsx
+++ b/packages/viewer/hooks/useIsMobile.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { act } from "react";
+import { renderHook } from "vitest-browser-react";
 import { useIsMobile } from "./useIsMobile";
 
 describe("useIsMobile Hook", () => {
@@ -53,61 +54,61 @@ describe("useIsMobile Hook", () => {
   };
 
   describe("基本機能", () => {
-    it("初期状態でデスクトップの場合falseを返す", () => {
+    it("初期状態でデスクトップの場合falseを返す", async () => {
       mediaQueryMatches = false;
-      const { result } = renderHook(() => useIsMobile());
+      const { result } = await renderHook(() => useIsMobile());
       expect(result.current).toBe(false);
     });
 
-    it("初期状態でモバイルの場合trueを返す", () => {
+    it("初期状態でモバイルの場合trueを返す", async () => {
       mediaQueryMatches = true;
-      const { result } = renderHook(() => useIsMobile());
+      const { result } = await renderHook(() => useIsMobile());
       expect(result.current).toBe(true);
     });
 
-    it("適切なmax-widthクエリを使用する", () => {
-      renderHook(() => useIsMobile());
+    it("適切なmax-widthクエリを使用する", async () => {
+      await renderHook(() => useIsMobile());
       expect(window.matchMedia).toHaveBeenCalledWith(expect.stringContaining("max-width"));
     });
   });
 
   describe("リアクティブな変更", () => {
-    it("メディアクエリの変更に応じて値が更新される", () => {
+    it("メディアクエリの変更に応じて値が更新される", async () => {
       mediaQueryMatches = false;
-      const { result } = renderHook(() => useIsMobile());
+      const { result } = await renderHook(() => useIsMobile());
 
       expect(result.current).toBe(false);
 
-      act(() => {
+      await act(() => {
         fireMediaChange(true);
       });
 
       expect(result.current).toBe(true);
     });
 
-    it("複数回の変更に対応する", () => {
+    it("複数回の変更に対応する", async () => {
       mediaQueryMatches = false;
-      const { result } = renderHook(() => useIsMobile());
+      const { result } = await renderHook(() => useIsMobile());
 
       expect(result.current).toBe(false);
 
-      act(() => fireMediaChange(true));
+      await act(() => fireMediaChange(true));
       expect(result.current).toBe(true);
 
-      act(() => fireMediaChange(false));
+      await act(() => fireMediaChange(false));
       expect(result.current).toBe(false);
     });
   });
 
   describe("クリーンアップ", () => {
-    it("アンマウント時にイベントリスナーを解除する", () => {
-      const { unmount } = renderHook(() => useIsMobile());
+    it("アンマウント時にイベントリスナーを解除する", async () => {
+      const { unmount } = await renderHook(() => useIsMobile());
 
       // Listeners are registered
       const changeListeners = [...listeners.entries()].filter(([k]) => k.endsWith(":change"));
       expect(changeListeners.length).toBeGreaterThan(0);
 
-      unmount();
+      await unmount();
 
       // After unmount, the change handler for our query should be removed
       for (const [key, handlers] of listeners) {
@@ -119,8 +120,8 @@ describe("useIsMobile Hook", () => {
   });
 
   describe("TypeScript型安全性", () => {
-    it("正しいboolean型を返す", () => {
-      const { result } = renderHook(() => useIsMobile());
+    it("正しいboolean型を返す", async () => {
+      const { result } = await renderHook(() => useIsMobile());
       expect(typeof result.current).toBe("boolean");
     });
   });

--- a/packages/viewer/hooks/usePaginatedQuery.test.tsx
+++ b/packages/viewer/hooks/usePaginatedQuery.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { worker } from "../test/mocks/browser";
-import { renderWithProviders, screen, waitFor } from "../test/utils/test-utils";
+import { renderWithProviders, screen } from "../test/utils/test-utils";
 import { usePaginatedQuery, type RelayConnection } from "./usePaginatedQuery";
 
 const TEST_ENDPOINT = import.meta.env.VITE_GRAPHQL_ENDPOINT;
@@ -50,11 +50,9 @@ describe("usePaginatedQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent variables={{ first: 10 }} />);
+    await renderWithProviders(<TestComponent variables={{ first: 10 }} />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Item A")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item A")).toBeInTheDocument();
   });
 
   it("Auth0ロード中はクエリを実行しない", async () => {
@@ -66,12 +64,12 @@ describe("usePaginatedQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent variables={{ first: 10 }} />, {
+    await renderWithProviders(<TestComponent variables={{ first: 10 }} />, {
       auth0Config: { isLoading: true, token: "" },
     });
 
-    expect(screen.getByText("loading")).toBeInTheDocument();
-    await waitFor(() => {
+    await expect.element(screen.getByText("loading")).toBeInTheDocument();
+    await vi.waitFor(() => {
       expect(requestCount).toBe(0);
     });
   });
@@ -89,21 +87,17 @@ describe("usePaginatedQuery", () => {
       })
     );
 
-    const { user } = renderWithProviders(<TestComponent variables={{ first: 10 }} />);
+    const { user } = await renderWithProviders(<TestComponent variables={{ first: 10 }} />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Item A")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item A")).toBeInTheDocument();
 
     await user.click(screen.getByText("load more"));
 
-    await waitFor(() => {
-      expect(screen.getByText("Item B")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item B")).toBeInTheDocument();
 
     // Both items should be present
-    expect(screen.getByText("Item A")).toBeInTheDocument();
-    expect(screen.getByText("Item B")).toBeInTheDocument();
+    await expect.element(screen.getByText("Item A")).toBeInTheDocument();
+    await expect.element(screen.getByText("Item B")).toBeInTheDocument();
   });
 
   it("hasNextPageがfalseの場合fetchMoreボタンが無効になる", async () => {
@@ -113,13 +107,11 @@ describe("usePaginatedQuery", () => {
       })
     );
 
-    renderWithProviders(<TestComponent variables={{ first: 10 }} />);
+    await renderWithProviders(<TestComponent variables={{ first: 10 }} />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Item A")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item A")).toBeInTheDocument();
 
-    expect(screen.getByText("load more")).toBeDisabled();
+    await expect.element(screen.getByText("load more")).toBeDisabled();
   });
 
   it("fetchMore中の重複呼び出しを防止する", async () => {
@@ -137,19 +129,15 @@ describe("usePaginatedQuery", () => {
       })
     );
 
-    const { user } = renderWithProviders(<TestComponent variables={{ first: 10 }} />);
+    const { user } = await renderWithProviders(<TestComponent variables={{ first: 10 }} />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Item A")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item A")).toBeInTheDocument();
 
     // Click fetchMore twice rapidly
     await user.click(screen.getByText("load more"));
     await user.click(screen.getByText("load more"));
 
-    await waitFor(() => {
-      expect(screen.getByText("Item B")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Item B")).toBeInTheDocument();
 
     // Only 2 requests total: initial + one fetchMore (not two)
     expect(callCount).toBe(2);
@@ -167,17 +155,15 @@ describe("usePaginatedQuery", () => {
       })
     );
 
-    const { rerender } = renderWithProviders(
+    const { rerender } = await renderWithProviders(
       <TestComponent variables={{ first: 10, filter: "X" }} />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText("Filtered X")).toBeInTheDocument();
-    });
+    await expect.element(screen.getByText("Filtered X")).toBeInTheDocument();
 
-    rerender(<TestComponent variables={{ first: 10, filter: "Y" }} />);
+    await rerender(<TestComponent variables={{ first: 10, filter: "Y" }} />);
 
-    await waitFor(() => {
+    await vi.waitFor(() => {
       expect(capturedVariables["filter"]).toBe("Y");
     });
   });

--- a/packages/viewer/hooks/useQueryParams.test.ts
+++ b/packages/viewer/hooks/useQueryParams.test.ts
@@ -1,4 +1,5 @@
-import { act, renderHook } from "@testing-library/react";
+import { act } from "react";
+import { renderHook } from "vitest-browser-react";
 import { describe, expect, test, vi } from "vitest";
 import { ArrayParam, DateParam, NumberParam, StringParam, useQueryParams } from "./useQueryParams";
 
@@ -93,10 +94,10 @@ describe("DateParam", () => {
 });
 
 describe("useQueryParams", () => {
-  test("all pattern", () => {
+  test("all pattern", async () => {
     const setLocationMock = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ search }) =>
+    const { result, rerender } = await renderHook(
+      (props?: { search: string }) =>
         useQueryParams(
           {
             a: NumberParam,
@@ -105,7 +106,7 @@ describe("useQueryParams", () => {
             d: DateParam,
           },
           setLocationMock,
-          search,
+          props?.search ?? "",
           ""
         ),
       { initialProps: { search: "a=12345&b=ABCDE&c=XXX&c=YYY&c=ZZZ&d=2022-02-26" } }
@@ -115,7 +116,7 @@ describe("useQueryParams", () => {
     expect(result.current[0].c?.sort().toString()).toBe(["XXX", "YYY", "ZZZ"].sort().toString());
     expect(result.current[0].d?.toISOString()).toBe(new Date("2022-02-26").toISOString());
 
-    act(() => {
+    await act(() => {
       result.current[1]({
         a: 54321,
         b: "EDCBA",
@@ -130,29 +131,30 @@ describe("useQueryParams", () => {
     expect(options).toEqual({ replace: true });
 
     // 要求された URL で再レンダされた（= wouter が URL を更新した）体で復号値を検証する。
-    rerender({ search: (to as string).split("?")[1] ?? "" });
+    await rerender({ search: (to as string).split("?")[1] ?? "" });
     expect(result.current[0].a).toBe(54321);
     expect(result.current[0].b).toBe("EDCBA");
     expect(result.current[0].c?.sort().toString()).toBe(["PPP", "QQQ", "RRR"].sort().toString());
     expect(result.current[0].d?.toISOString()).toBe(new Date("2022-02-27").toISOString());
   });
-  test("search prop の変更で復号値が再同期する", () => {
+  test("search prop の変更で復号値が再同期する", async () => {
     // ブラウザの戻る/進むで wouter の useSearch() が新しい値を返す状況の再現。
     // 内部 state に固定していると search 変更を無視してしまう（このテストが再同期を強制する）。
-    const { result, rerender } = renderHook(
-      ({ search }) => useQueryParams({ a: NumberParam, b: StringParam }, () => {}, search, ""),
+    const { result, rerender } = await renderHook(
+      (props?: { search: string }) =>
+        useQueryParams({ a: NumberParam, b: StringParam }, () => {}, props?.search ?? "", ""),
       { initialProps: { search: "a=1&b=first" } }
     );
     expect(result.current[0].a).toBe(1);
     expect(result.current[0].b).toBe("first");
 
-    rerender({ search: "a=2&b=second" });
+    await rerender({ search: "a=2&b=second" });
 
     expect(result.current[0].a).toBe(2);
     expect(result.current[0].b).toBe("second");
   });
-  test("empty parameters", () => {
-    const { result } = renderHook(() =>
+  test("empty parameters", async () => {
+    const { result } = await renderHook(() =>
       useQueryParams(
         {
           a: NumberParam,
@@ -170,8 +172,8 @@ describe("useQueryParams", () => {
     expect(result.current[0].c).toBeUndefined();
     expect(result.current[0].d).toBeUndefined();
   });
-  test("other parameters", () => {
-    const { result } = renderHook(() =>
+  test("other parameters", async () => {
+    const { result } = await renderHook(() =>
       useQueryParams(
         {
           a: NumberParam,
@@ -194,9 +196,9 @@ describe("useQueryParams", () => {
     expect(result.current[0].f).toBeNull();
   });
 
-  test("setQueryParams with array values exercises toQueryParams array branch", () => {
+  test("setQueryParams with array values exercises toQueryParams array branch", async () => {
     const setLocationMock = vi.fn();
-    const { result } = renderHook(() =>
+    const { result } = await renderHook(() =>
       useQueryParams(
         {
           tags: ArrayParam,
@@ -208,7 +210,7 @@ describe("useQueryParams", () => {
       )
     );
 
-    act(() => {
+    await act(() => {
       result.current[1]({
         tags: ["a", "b", "c"],
         count: 5,
@@ -223,9 +225,9 @@ describe("useQueryParams", () => {
     expect(params.get("count")).toBe("5");
   });
 
-  test("setQueryParams with null encode result deletes parameter from URL", () => {
+  test("setQueryParams with null encode result deletes parameter from URL", async () => {
     const setLocationMock = vi.fn();
-    const { result } = renderHook(() =>
+    const { result } = await renderHook(() =>
       useQueryParams(
         {
           name: StringParam,
@@ -241,7 +243,7 @@ describe("useQueryParams", () => {
     expect(result.current[0].value).toBe("world");
 
     // name を null にすると URL から削除され、value は残る。
-    act(() => {
+    await act(() => {
       result.current[1]({
         name: null as unknown as string,
       });
@@ -250,8 +252,8 @@ describe("useQueryParams", () => {
     expect(setLocationMock).toHaveBeenCalledWith("/test?value=world", { replace: true });
   });
 
-  test("toDecodedValues with existing query params maps all keys", () => {
-    const { result } = renderHook(() =>
+  test("toDecodedValues with existing query params maps all keys", async () => {
+    const { result } = await renderHook(() =>
       useQueryParams(
         {
           name: StringParam,

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -13,17 +13,15 @@
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",
-    "@testing-library/jest-dom": "6.9.1",
-    "@testing-library/react": "16.3.2",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.3",
-    "@vitest/browser": "4.1.10",
     "@vitest/browser-playwright": "4.1.10",
     "@vitest/coverage-istanbul": "4.1.10",
     "msw": "2.15.0",
     "vite": "8.1.5",
     "vitest": "4.1.10",
+    "vitest-browser-react": "2.2.0",
     "wrangler": "4.111.0"
   },
   "scripts": {

--- a/packages/viewer/pages/Detail.test.tsx
+++ b/packages/viewer/pages/Detail.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { worker } from "../test/mocks/browser";
-import { renderWithProviders, screen, waitFor } from "../test/utils/test-utils";
+import { renderWithProviders, screen } from "../test/utils/test-utils";
 import {
   createMockInstitutionDetailNode,
   createMockInstitutionDetailConnection,
@@ -70,14 +70,14 @@ const useMswDetailMock = (
 
 describe("Detail Page", () => {
   describe("無効なUUID", () => {
-    it("無効なUUIDの場合、トップページにリダイレクトする", () => {
-      renderWithProviders(<DetailPage />, {
+    it("無効なUUIDの場合、トップページにリダイレクトする", async () => {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: ["/institution/not-a-uuid"],
         route: "/institution/:id",
       });
 
-      expect(screen.queryByText("施設情報")).not.toBeInTheDocument();
-      expect(screen.queryByText("予約状況")).not.toBeInTheDocument();
+      await expect.element(screen.getByText("施設情報")).not.toBeInTheDocument();
+      await expect.element(screen.getByText("予約状況")).not.toBeInTheDocument();
     });
   });
 
@@ -85,16 +85,14 @@ describe("Detail Page", () => {
     it("施設名（建物名＋施設名）を表示する", async () => {
       useMswDetailMock();
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
     });
 
     it("website_urlがある場合にリンクアイコンが表示される", async () => {
@@ -104,14 +102,14 @@ describe("Detail Page", () => {
       const responseWithUrl = createMockInstitutionDetailConnection(nodeWithUrl);
       useMswDetailMock(responseWithUrl);
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
       });
 
-      await waitFor(() => {
+      await vi.waitFor(() => {
         const link = document.querySelector('a[href="https://example.com"]');
-        expect(link).toBeInTheDocument();
+        expect(link).not.toBeNull();
       });
     });
 
@@ -123,94 +121,89 @@ describe("Detail Page", () => {
       const responseWithNull = createMockInstitutionDetailConnection(nodeWithNull);
       useMswDetailMock(responseWithNull);
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
       });
 
-      await waitFor(() => {
-        const heading = screen.getByRole("heading", { level: 2 });
-        expect(heading).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
     });
 
     it("「施設情報」タブがデフォルトでアクティブである", async () => {
       useMswDetailMock();
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
       });
 
       const institutionTab = screen.getByRole("tab", { name: "施設情報" });
-      expect(institutionTab).toHaveAttribute("aria-selected", "true");
+      await expect.element(institutionTab).toHaveAttribute("aria-selected", "true");
     });
 
     it("施設の詳細情報のInput項目を表示する", async () => {
       useMswDetailMock();
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("定員（人）")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("定員（人）")).toBeInTheDocument();
 
-      expect(screen.getByText("面積（㎡）")).toBeInTheDocument();
-      expect(screen.getByText("利用料金（平日）")).toBeInTheDocument();
-      expect(screen.getByText("利用料金（休日）")).toBeInTheDocument();
-      expect(screen.getByText("弦楽器")).toBeInTheDocument();
-      expect(screen.getByText("木管楽器")).toBeInTheDocument();
-      expect(screen.getByText("金管楽器")).toBeInTheDocument();
-      expect(screen.getByText("打楽器")).toBeInTheDocument();
-      expect(screen.getByText("譜面台")).toBeInTheDocument();
-      expect(screen.getByText("ピアノ")).toBeInTheDocument();
-      expect(screen.getByText("住所")).toBeInTheDocument();
-      expect(screen.getByText("抽選期間")).toBeInTheDocument();
-      expect(screen.getByText("備考")).toBeInTheDocument();
+      await expect.element(screen.getByText("面積（㎡）")).toBeInTheDocument();
+      await expect.element(screen.getByText("利用料金（平日）")).toBeInTheDocument();
+      await expect.element(screen.getByText("利用料金（休日）")).toBeInTheDocument();
+      await expect.element(screen.getByText("弦楽器")).toBeInTheDocument();
+      await expect.element(screen.getByText("木管楽器")).toBeInTheDocument();
+      await expect.element(screen.getByText("金管楽器")).toBeInTheDocument();
+      await expect.element(screen.getByText("打楽器")).toBeInTheDocument();
+      await expect.element(screen.getByText("譜面台")).toBeInTheDocument();
+      await expect.element(screen.getByText("ピアノ")).toBeInTheDocument();
+      await expect.element(screen.getByText("住所")).toBeInTheDocument();
+      await expect.element(screen.getByText("抽選期間")).toBeInTheDocument();
+      await expect.element(screen.getByText("備考")).toBeInTheDocument();
     });
   });
 
   describe("認証状態による「予約状況」タブの制御", () => {
-    it("anonymousユーザーの場合、「予約状況」タブが無効になる", () => {
+    it("anonymousユーザーの場合、「予約状況」タブが無効になる", async () => {
       useMswDetailMock();
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: true, trial: false } },
       });
 
       const reservationTab = screen.getByRole("tab", { name: "予約状況" });
-      expect(reservationTab).toBeDisabled();
+      await expect.element(reservationTab).toBeDisabled();
     });
 
-    it("trialユーザーの場合、「予約状況」タブが無効になる", () => {
+    it("trialユーザーの場合、「予約状況」タブが無効になる", async () => {
       useMswDetailMock();
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: true } },
       });
 
       const reservationTab = screen.getByRole("tab", { name: "予約状況" });
-      expect(reservationTab).toBeDisabled();
+      await expect.element(reservationTab).toBeDisabled();
     });
 
-    it("認証済みユーザーの場合、「予約状況」タブが有効になる", () => {
+    it("認証済みユーザーの場合、「予約状況」タブが有効になる", async () => {
       useMswDetailMock();
 
-      renderWithProviders(<DetailPage />, {
+      await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
       const reservationTab = screen.getByRole("tab", { name: "予約状況" });
-      expect(reservationTab).toBeEnabled();
+      await expect.element(reservationTab).toBeEnabled();
     });
   });
 
@@ -233,24 +226,20 @@ describe("Detail Page", () => {
         createMockInstitutionReservationsConnection([reservationNode1, reservationNode2])
       );
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("日付")).toBeInTheDocument();
-      });
-      expect(screen.getByText("取得日時")).toBeInTheDocument();
+      await expect.element(screen.getByText("日付")).toBeInTheDocument();
+      await expect.element(screen.getByText("取得日時")).toBeInTheDocument();
     });
 
     it("予約クエリの startDate にレンダ時点の本日を渡す", async () => {
@@ -270,23 +259,21 @@ describe("Detail Page", () => {
         })
       );
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
       // module-level `new Date()` だと import 時刻（実時刻）を固定してしまう。
       // レンダ時評価なら setSystemTime(FAKE_NOW) を読むため 2025-06-15 になる。
-      await waitFor(() => {
+      await vi.waitFor(() => {
         expect(capturedStartDate).toBe("2025-06-15");
       });
     });
@@ -294,23 +281,19 @@ describe("Detail Page", () => {
     it("予約データが空の場合、データなしメッセージを表示する", async () => {
       useMswDetailMock(defaultDetailResponse, createMockInstitutionReservationsConnection([]));
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
     });
 
     it("予約状況除外対象の自治体の場合、データなしメッセージを表示する", async () => {
@@ -324,23 +307,19 @@ describe("Detail Page", () => {
         createMockInstitutionReservationsConnection([createMockReservationNode()])
       );
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
     });
 
     it("予約データ取得中にスピナーを表示する", async () => {
@@ -349,23 +328,21 @@ describe("Detail Page", () => {
         reservationDelay: 60000,
       });
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
-      await waitFor(() => {
-        expect(screen.getByRole("progressbar", { name: "読み込み中" })).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("progressbar", { name: "読み込み中" }))
+        .toBeInTheDocument();
     });
 
     it("予約データ取得でエラーが発生した場合、ErrorBoundaryがエラーをキャッチする", async () => {
@@ -376,7 +353,7 @@ describe("Detail Page", () => {
         reservationError: true,
       });
 
-      const { user } = renderWithProviders(
+      const { user } = await renderWithProviders(
         <ErrorBoundary>
           <DetailPage />
         </ErrorBoundary>,
@@ -387,21 +364,19 @@ describe("Detail Page", () => {
         }
       );
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
-      await waitFor(() => {
-        expect(
+      await expect
+        .element(
           screen.getByText(
             "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
           )
-        ).toBeInTheDocument();
-      });
+        )
+        .toBeInTheDocument();
 
       consoleSpy.mockRestore();
       consoleLogSpy.mockRestore();
@@ -415,7 +390,7 @@ describe("Detail Page", () => {
         detailError: true,
       });
 
-      renderWithProviders(
+      await renderWithProviders(
         <ErrorBoundary>
           <DetailPage />
         </ErrorBoundary>,
@@ -426,13 +401,13 @@ describe("Detail Page", () => {
         }
       );
 
-      await waitFor(() => {
-        expect(
+      await expect
+        .element(
           screen.getByText(
             "予期せぬエラーが発生しました。再読み込みしてください。何度も発生する場合は管理者にお問い合わせください。"
           )
-        ).toBeInTheDocument();
-      });
+        )
+        .toBeInTheDocument();
 
       consoleSpy.mockRestore();
       consoleLogSpy.mockRestore();
@@ -465,21 +440,19 @@ describe("Detail Page", () => {
         createMockInstitutionReservationsConnection([reservationNode1, reservationNode2])
       );
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
       });
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ })
-        ).toBeInTheDocument();
-      });
+      await expect
+        .element(screen.getByRole("heading", { name: /テスト文化センター 音楽練習室A/ }))
+        .toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "予約状況" }));
 
-      await waitFor(() => {
+      await vi.waitFor(() => {
         const allText = document.body.textContent || "";
         expect(allText).toContain("2024");
         expect(allText).toContain("2025");
@@ -491,7 +464,7 @@ describe("Detail Page", () => {
     it("タブをクリックするとタブが切り替わる", async () => {
       useMswDetailMock(defaultDetailResponse, createMockInstitutionReservationsConnection([]));
 
-      const { user } = renderWithProviders(<DetailPage />, {
+      const { user } = await renderWithProviders(<DetailPage />, {
         initialEntries: [`/institution/${VALID_UUID}`],
         route: "/institution/:id",
         auth0Config: { userInfo: { anonymous: false, trial: false } },
@@ -499,13 +472,13 @@ describe("Detail Page", () => {
 
       const institutionTab = screen.getByRole("tab", { name: "施設情報" });
       const reservationTab = screen.getByRole("tab", { name: "予約状況" });
-      expect(institutionTab).toHaveAttribute("aria-selected", "true");
-      expect(reservationTab).toHaveAttribute("aria-selected", "false");
+      await expect.element(institutionTab).toHaveAttribute("aria-selected", "true");
+      await expect.element(reservationTab).toHaveAttribute("aria-selected", "false");
 
       await user.click(reservationTab);
 
-      expect(reservationTab).toHaveAttribute("aria-selected", "true");
-      expect(institutionTab).toHaveAttribute("aria-selected", "false");
+      await expect.element(reservationTab).toHaveAttribute("aria-selected", "true");
+      await expect.element(institutionTab).toHaveAttribute("aria-selected", "false");
     });
   });
 });

--- a/packages/viewer/pages/Institution.test.tsx
+++ b/packages/viewer/pages/Institution.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { worker } from "../test/mocks/browser";
-import { renderWithProviders, screen, waitFor } from "../test/utils/test-utils";
+import { renderWithProviders, screen } from "../test/utils/test-utils";
 import { createMockInstitutionNode, createMockInstitutionsConnection } from "../test/mocks/data";
 import InstitutionPage, { COLUMNS } from "./Institution";
 
@@ -106,38 +106,36 @@ describe("Institution Page", () => {
     it("絞り込みボタンを押すと地区のSelect、利用可能楽器、施設サイズが表示される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("地区")).toBeInTheDocument();
-      });
-      expect(screen.getByText("利用可能楽器")).toBeInTheDocument();
-      expect(screen.getByText("施設サイズ")).toBeInTheDocument();
+      await expect.element(screen.getByText("地区")).toBeInTheDocument();
+      await expect.element(screen.getByText("利用可能楽器")).toBeInTheDocument();
+      await expect.element(screen.getByText("施設サイズ")).toBeInTheDocument();
     });
 
-    it("選択した地区がチップとして表示される", () => {
+    it("選択した地区がチップとして表示される", async () => {
       useMswMock([]);
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      expect(screen.getByText("江東区")).toBeInTheDocument();
+      await expect.element(screen.getByText("江東区")).toBeInTheDocument();
     });
 
-    it("municipality=allの場合、地区チップが表示されない", () => {
+    it("municipality=allの場合、地区チップが表示されない", async () => {
       useMswMock([]);
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution"],
       });
 
-      expect(screen.queryByText("江東区")).not.toBeInTheDocument();
-      expect(screen.queryByText("すべて")).not.toBeInTheDocument();
+      await expect.element(screen.getByText("江東区")).not.toBeInTheDocument();
+      await expect.element(screen.getByText("すべて")).not.toBeInTheDocument();
     });
   });
 
@@ -145,23 +143,21 @@ describe("Institution Page", () => {
     it("地区を変更するとチップが更新される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      expect(screen.getByText("江東区")).toBeInTheDocument();
+      await expect.element(screen.getByText("江東区")).toBeInTheDocument();
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByRole("combobox", { name: "地区" })).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("combobox", { name: "地区" })).toBeInTheDocument();
 
       const selectElement = screen.getByRole("combobox", { name: "地区" });
       await user.selectOptions(selectElement, "MUNICIPALITY_KITA");
 
-      await waitFor(() => {
-        const elements = screen.getAllByText("北区");
+      await vi.waitFor(() => {
+        const elements = screen.getByText("北区").all();
         expect(elements.length).toBeGreaterThanOrEqual(1);
       });
     });
@@ -169,20 +165,18 @@ describe("Institution Page", () => {
     it("利用可能楽器チェックボックスを切り替えるとチップが追加される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("利用可能楽器")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("利用可能楽器")).toBeInTheDocument();
 
       await user.click(screen.getByRole("checkbox", { name: "弦楽器" }));
 
-      await waitFor(() => {
-        const chips = screen.getAllByText("弦楽器");
+      await vi.waitFor(() => {
+        const chips = screen.getByText("弦楽器").all();
         expect(chips.length).toBeGreaterThanOrEqual(2);
       });
     });
@@ -190,66 +184,56 @@ describe("Institution Page", () => {
     it("利用可能楽器チェックボックスをオフにするとチップが削除される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou&a=s"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("利用可能楽器")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("利用可能楽器")).toBeInTheDocument();
 
       const checkbox = screen.getByRole("checkbox", { name: "弦楽器" });
-      expect(checkbox).toBeChecked();
+      await expect.element(checkbox).toBeChecked();
 
       await user.click(checkbox);
 
-      await waitFor(() => {
-        expect(checkbox).not.toBeChecked();
-      });
+      await expect.element(checkbox).not.toBeChecked();
     });
 
     it("施設サイズチェックボックスをオフにするとチップが削除される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou&i=l"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("施設サイズ")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設サイズ")).toBeInTheDocument();
 
       const checkbox = screen.getByRole("checkbox", { name: "大（100㎡~）" });
-      expect(checkbox).toBeChecked();
+      await expect.element(checkbox).toBeChecked();
 
       await user.click(checkbox);
 
-      await waitFor(() => {
-        expect(checkbox).not.toBeChecked();
-      });
+      await expect.element(checkbox).not.toBeChecked();
     });
 
     it("施設サイズチェックボックスを切り替えるとチップが追加される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("施設サイズ")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設サイズ")).toBeInTheDocument();
 
       await user.click(screen.getByRole("checkbox", { name: "大（100㎡~）" }));
 
-      await waitFor(() => {
-        const chips = screen.getAllByText("大（100㎡~）");
+      await vi.waitFor(() => {
+        const chips = screen.getByText("大（100㎡~）").all();
         expect(chips.length).toBeGreaterThanOrEqual(2);
       });
     });
@@ -259,18 +243,16 @@ describe("Institution Page", () => {
     it("データが存在しないメッセージを表示する", async () => {
       useMswMock([]);
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
     });
   });
 
   describe("ローディング状態", () => {
-    it("データ取得中にスピナーを表示する", () => {
+    it("データ取得中にスピナーを表示する", async () => {
       // Use a handler that delays indefinitely
       worker.use(
         http.post(TEST_ENDPOINT, async () => {
@@ -279,11 +261,13 @@ describe("Institution Page", () => {
         })
       );
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      expect(screen.getByRole("progressbar", { name: "読み込み中" })).toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("progressbar", { name: "読み込み中" }))
+        .toBeInTheDocument();
     });
   });
 
@@ -297,14 +281,12 @@ describe("Institution Page", () => {
         })
       );
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByRole("alert")).toBeInTheDocument();
-        expect(screen.getByText("Network error")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+      await expect.element(screen.getByText("Network error")).toBeInTheDocument();
     });
   });
 
@@ -324,16 +306,14 @@ describe("Institution Page", () => {
 
       useMswMock([node1, node2]);
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("施設名")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設名")).toBeInTheDocument();
 
-      expect(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
-      expect(screen.getByText("サンプル会館 リハーサル室B")).toBeInTheDocument();
+      await expect.element(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
+      await expect.element(screen.getByText("サンプル会館 リハーサル室B")).toBeInTheDocument();
     });
 
     it("hasNextPageがtrueでendCursorが存在する場合、IntersectionObserver発火時にfetchMoreが呼ばれる", async () => {
@@ -365,16 +345,14 @@ describe("Institution Page", () => {
         })
       );
 
-      renderWithProviders(<InstitutionPage />, {
+      await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("施設ビル0 練習室0")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設ビル0 練習室0")).toBeInTheDocument();
 
       // Wait for the IntersectionObserver to fire and fetchMore to be called
-      await waitFor(
+      await vi.waitFor(
         () => {
           expect(requestCount).toBeGreaterThanOrEqual(2);
         },
@@ -390,17 +368,15 @@ describe("Institution Page", () => {
 
       useMswMock([node]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
 
       const cell = screen.getByText("テスト文化センター 音楽練習室A");
-      const row = cell.closest("tr");
-      expect(row).toHaveStyle({ cursor: "pointer" });
+      const row = cell.element().closest("tr");
+      await expect.element(row).toHaveStyle({ cursor: "pointer" });
 
       await user.click(cell);
     });
@@ -414,17 +390,15 @@ describe("Institution Page", () => {
 
       useMswMock([invalidNode]);
 
-      const { user } = renderWithProviders(<InstitutionPage />, {
+      const { user } = await renderWithProviders(<InstitutionPage />, {
         initialEntries: ["/institution?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("無効ID施設 テスト室")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("無効ID施設 テスト室")).toBeInTheDocument();
 
       await user.click(screen.getByText("無効ID施設 テスト室"));
 
-      expect(screen.getByText("無効ID施設 テスト室")).toBeInTheDocument();
+      await expect.element(screen.getByText("無効ID施設 テスト室")).toBeInTheDocument();
     });
   });
 });

--- a/packages/viewer/pages/Loading.test.tsx
+++ b/packages/viewer/pages/Loading.test.tsx
@@ -3,20 +3,20 @@ import { renderWithProviders, screen } from "../test/utils/test-utils";
 import { Loading } from "./Loading";
 
 describe("Loading Page", () => {
-  it("Spinnerコンポーネントをレンダリングする", () => {
-    renderWithProviders(<Loading />);
+  it("Spinnerコンポーネントをレンダリングする", async () => {
+    await renderWithProviders(<Loading />);
 
     const spinner = screen.getByRole("progressbar");
-    expect(spinner).toBeInTheDocument();
+    await expect.element(spinner).toBeInTheDocument();
   });
 
-  it("main要素内にSpinnerを表示する", () => {
-    renderWithProviders(<Loading />);
+  it("main要素内にSpinnerを表示する", async () => {
+    await renderWithProviders(<Loading />);
 
     const main = screen.getByRole("main");
-    expect(main).toBeInTheDocument();
+    await expect.element(main).toBeInTheDocument();
 
     const spinner = screen.getByRole("progressbar");
-    expect(main).toContainElement(spinner);
+    await expect.element(main).toContainElement(spinner.element());
   });
 });

--- a/packages/viewer/pages/Reservation.test.tsx
+++ b/packages/viewer/pages/Reservation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { worker } from "../test/mocks/browser";
-import { fireEvent, renderWithProviders, screen, waitFor } from "../test/utils/test-utils";
+import { renderWithProviders, screen } from "../test/utils/test-utils";
 import {
   createMockSearchableReservationNode,
   createMockSearchableReservationsConnection,
@@ -140,64 +140,62 @@ describe("Reservation Page", () => {
     it("絞り込みボタンを押すとSelect、DateRangePicker、CheckboxGroupが表示される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("地区")).toBeInTheDocument();
-      });
-      expect(screen.getByText("期間指定")).toBeInTheDocument();
-      expect(screen.getByText("絞り込み", { selector: "span" })).toBeInTheDocument();
-      expect(screen.getByText("利用可能楽器")).toBeInTheDocument();
-      expect(screen.getByText("施設サイズ")).toBeInTheDocument();
+      await expect.element(screen.getByText("地区")).toBeInTheDocument();
+      await expect.element(screen.getByText("期間指定")).toBeInTheDocument();
+      await expect.element(screen.getByText("絞り込み", { exact: true })).toBeInTheDocument();
+      await expect.element(screen.getByText("利用可能楽器")).toBeInTheDocument();
+      await expect.element(screen.getByText("施設サイズ")).toBeInTheDocument();
     });
 
-    it("選択した地区と日付範囲がチップとして表示される", () => {
+    it("選択した地区と日付範囲がチップとして表示される", async () => {
       useMswMock([]);
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      expect(screen.getByText("江東区")).toBeInTheDocument();
-      expect(screen.getByText(/2025\/06\/15.*〜.*2025\/07\/15/)).toBeInTheDocument();
+      await expect.element(screen.getByText("江東区")).toBeInTheDocument();
+      await expect.element(screen.getByText(/2025\/06\/15.*〜.*2025\/07\/15/)).toBeInTheDocument();
     });
 
-    it("municipality=allの場合、地区チップが表示されない", () => {
+    it("municipality=allの場合、地区チップが表示されない", async () => {
       useMswMock([]);
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation"],
       });
 
       // When no municipality param is set, defaults to "all"
       // The municipality chip should not appear, only the date range chip
-      expect(screen.queryByText("江東区")).not.toBeInTheDocument();
-      expect(screen.queryByText("すべて")).not.toBeInTheDocument();
-      expect(screen.getByText(/2025\/06\/15.*〜.*2025\/07\/15/)).toBeInTheDocument();
+      await expect.element(screen.getByText("江東区")).not.toBeInTheDocument();
+      await expect.element(screen.getByText("すべて")).not.toBeInTheDocument();
+      await expect.element(screen.getByText(/2025\/06\/15.*〜.*2025\/07\/15/)).toBeInTheDocument();
     });
 
     it("予約状況除外対象の自治体がSelectの選択肢から除外されている", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer to access Select
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByRole("combobox", { name: "地区" })).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("combobox", { name: "地区" })).toBeInTheDocument();
 
       // For native <select>, check <option> elements directly (always in the DOM)
       const select = screen.getByRole("combobox", { name: "地区" });
-      const optionTexts = Array.from(select.querySelectorAll("option")).map((o) => o.textContent);
+      const optionTexts = Array.from(select.element().querySelectorAll("option")).map(
+        (o) => o.textContent
+      );
 
       // Non-excluded municipalities should be present as options
       expect(optionTexts).toContain("江東区");
@@ -215,27 +213,25 @@ describe("Reservation Page", () => {
     it("地区を変更するとチップが更新される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Verify initial chip
-      expect(screen.getByText("江東区")).toBeInTheDocument();
+      await expect.element(screen.getByText("江東区")).toBeInTheDocument();
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByRole("combobox", { name: "地区" })).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("combobox", { name: "地区" })).toBeInTheDocument();
 
-      // For native <select>, use fireEvent.change to change the value
+      // For native <select>, use selectOptions to change the value
       const select = screen.getByRole("combobox", { name: "地区" });
-      fireEvent.change(select, { target: { value: "MUNICIPALITY_KITA" } });
+      await user.selectOptions(select, "MUNICIPALITY_KITA");
 
       // The chip should update to "北区"
-      await waitFor(() => {
-        const elements = screen.getAllByText("北区");
+      await vi.waitFor(() => {
+        const elements = screen.getByText("北区").all();
         expect(elements.length).toBeGreaterThanOrEqual(1);
       });
     });
@@ -243,23 +239,21 @@ describe("Reservation Page", () => {
     it("利用可能楽器チェックボックスを切り替えるとチップが追加される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("利用可能楽器")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("利用可能楽器")).toBeInTheDocument();
 
       // Click the "弦楽器" checkbox
       await user.click(screen.getByRole("checkbox", { name: "弦楽器" }));
 
       // The chip "弦楽器" should appear (label + chip)
-      await waitFor(() => {
-        const chips = screen.getAllByText("弦楽器");
+      await vi.waitFor(() => {
+        const chips = screen.getByText("弦楽器").all();
         expect(chips.length).toBeGreaterThanOrEqual(2);
       });
     });
@@ -267,23 +261,21 @@ describe("Reservation Page", () => {
     it("施設サイズチェックボックスを切り替えるとチップが追加される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("施設サイズ")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設サイズ")).toBeInTheDocument();
 
       // Click the "大（100㎡~）" checkbox
       await user.click(screen.getByRole("checkbox", { name: "大（100㎡~）" }));
 
       // The chip should appear (label + chip)
-      await waitFor(() => {
-        const chips = screen.getAllByText("大（100㎡~）");
+      await vi.waitFor(() => {
+        const chips = screen.getByText("大（100㎡~）").all();
         expect(chips.length).toBeGreaterThanOrEqual(2);
       });
     });
@@ -291,90 +283,75 @@ describe("Reservation Page", () => {
     it("利用可能楽器チェックボックスをオフにするとチップが削除される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou&a=s"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("利用可能楽器")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("利用可能楽器")).toBeInTheDocument();
 
       const checkbox = screen.getByRole("checkbox", { name: "弦楽器" });
-      expect(checkbox).toBeChecked();
+      await expect.element(checkbox).toBeChecked();
 
       await user.click(checkbox);
 
-      await waitFor(() => {
-        expect(checkbox).not.toBeChecked();
-      });
+      await expect.element(checkbox).not.toBeChecked();
     });
 
     it("施設サイズチェックボックスをオフにするとチップが削除される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou&i=l"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("施設サイズ")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設サイズ")).toBeInTheDocument();
 
       const checkbox = screen.getByRole("checkbox", { name: "大（100㎡~）" });
-      expect(checkbox).toBeChecked();
+      await expect.element(checkbox).toBeChecked();
 
       await user.click(checkbox);
 
-      await waitFor(() => {
-        expect(checkbox).not.toBeChecked();
-      });
+      await expect.element(checkbox).not.toBeChecked();
     });
 
     it("絞り込みチェックボックスをオフにするとチップが削除される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou&f=m"],
       });
 
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        const checkbox = screen.getByRole("checkbox", { name: "午前空き" });
-        expect(checkbox).toBeChecked();
-      });
+      await expect.element(screen.getByRole("checkbox", { name: "午前空き" })).toBeChecked();
 
       await user.click(screen.getByRole("checkbox", { name: "午前空き" }));
 
-      await waitFor(() => {
-        expect(screen.getByRole("checkbox", { name: "午前空き" })).not.toBeChecked();
-      });
+      await expect.element(screen.getByRole("checkbox", { name: "午前空き" })).not.toBeChecked();
     });
 
     it("絞り込みチェックボックスを切り替えるとチップが追加される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByRole("checkbox", { name: "午前空き" })).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("checkbox", { name: "午前空き" })).toBeInTheDocument();
 
       // Click the "午前空き" checkbox
       await user.click(screen.getByRole("checkbox", { name: "午前空き" }));
 
       // The chip "午前空き" should appear (label + chip)
-      await waitFor(() => {
-        const chips = screen.getAllByText("午前空き");
+      await vi.waitFor(() => {
+        const chips = screen.getByText("午前空き").all();
         expect(chips.length).toBeGreaterThanOrEqual(2);
       });
     });
@@ -384,18 +361,16 @@ describe("Reservation Page", () => {
     it("データが存在しないメッセージを表示する", async () => {
       useMswMock([]);
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("表示するデータが存在しません")).toBeInTheDocument();
     });
   });
 
   describe("ローディング状態", () => {
-    it("データ取得中にスピナーを表示する", () => {
+    it("データ取得中にスピナーを表示する", async () => {
       // Use a handler that delays indefinitely
       worker.use(
         http.post(TEST_ENDPOINT, async () => {
@@ -404,11 +379,13 @@ describe("Reservation Page", () => {
         })
       );
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      expect(screen.getByRole("progressbar", { name: "読み込み中" })).toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("progressbar", { name: "読み込み中" }))
+        .toBeInTheDocument();
     });
   });
 
@@ -422,14 +399,12 @@ describe("Reservation Page", () => {
         })
       );
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByRole("alert")).toBeInTheDocument();
-        expect(screen.getByText("Network error")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByRole("alert")).toBeInTheDocument();
+      await expect.element(screen.getByText("Network error")).toBeInTheDocument();
     });
   });
 
@@ -437,109 +412,93 @@ describe("Reservation Page", () => {
     it("handleStartDateChange: 新しい開始日が終了日より前の場合、終了日は変更されない", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("期間指定")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("期間指定")).toBeInTheDocument();
 
       // Find the start date input (first input[type="date"])
       const dateInputs = document.querySelectorAll('input[type="date"]');
       expect(dateInputs.length).toBeGreaterThanOrEqual(2);
 
       // Change start date to June 20 (before July 15 endDate)
-      fireEvent.change(dateInputs[0]!, { target: { value: "2025-06-20" } });
+      await user.fill(dateInputs[0]!, "2025-06-20");
 
       // Wait for chip to update: startDate = June 20, endDate = July 15 (unchanged)
-      await waitFor(() => {
-        expect(screen.getByText(/2025\/06\/20.*〜.*2025\/07\/15/)).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText(/2025\/06\/20.*〜.*2025\/07\/15/)).toBeInTheDocument();
     });
 
     it("handleStartDateChange: 新しい開始日が終了日より後の場合、終了日も更新される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou&dt=2025-06-20"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("期間指定")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("期間指定")).toBeInTheDocument();
 
       // Find the start date input (first input[type="date"])
       const dateInputs = document.querySelectorAll('input[type="date"]');
       expect(dateInputs.length).toBeGreaterThanOrEqual(2);
 
       // Change start date to June 25 (after June 20 endDate)
-      fireEvent.change(dateInputs[0]!, { target: { value: "2025-06-25" } });
+      await user.fill(dateInputs[0]!, "2025-06-25");
 
       // Wait for chip to update: both start and end should be June 25
-      await waitFor(() => {
-        expect(screen.getByText(/2025\/06\/25.*〜.*2025\/06\/25/)).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText(/2025\/06\/25.*〜.*2025\/06\/25/)).toBeInTheDocument();
     });
 
     it("handleEndDateChange: 新しい終了日が開始日より後の場合、開始日は変更されない", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("期間指定")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("期間指定")).toBeInTheDocument();
 
       // Find the end date input (second input[type="date"])
       const dateInputs = document.querySelectorAll('input[type="date"]');
       expect(dateInputs.length).toBeGreaterThanOrEqual(2);
 
       // Change end date to July 10 (after June 15 startDate)
-      fireEvent.change(dateInputs[1]!, { target: { value: "2025-07-10" } });
+      await user.fill(dateInputs[1]!, "2025-07-10");
 
       // startDate unchanged (June 15), endDate = July 10
-      await waitFor(() => {
-        expect(screen.getByText(/2025\/06\/15.*〜.*2025\/07\/10/)).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText(/2025\/06\/15.*〜.*2025\/07\/10/)).toBeInTheDocument();
     });
 
     it("handleEndDateChange: 新しい終了日が開始日より前の場合、開始日も更新される", async () => {
       useMswMock([]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou&df=2025-06-20"],
       });
 
       // Open the drawer
       await user.click(screen.getByRole("button", { name: "絞り込み" }));
 
-      await waitFor(() => {
-        expect(screen.getByText("期間指定")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("期間指定")).toBeInTheDocument();
 
       // Find the end date input (second input[type="date"])
       const dateInputs = document.querySelectorAll('input[type="date"]');
       expect(dateInputs.length).toBeGreaterThanOrEqual(2);
 
       // Change end date to June 18 (before June 20 startDate)
-      fireEvent.change(dateInputs[1]!, { target: { value: "2025-06-18" } });
+      await user.fill(dateInputs[1]!, "2025-06-18");
 
       // Wait for chip to update: both start and end should be June 18
-      await waitFor(() => {
-        expect(screen.getByText(/2025\/06\/18.*〜.*2025\/06\/18/)).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText(/2025\/06\/18.*〜.*2025\/06\/18/)).toBeInTheDocument();
     });
   });
 
@@ -572,6 +531,10 @@ describe("Reservation Page", () => {
           requestCount++;
           const body = (await request.json()) as { variables: Record<string, unknown> };
           if (body.variables["after"]) {
+            // fetchMore 応答を遅らせ、スケルトン行（hasNextPage=true の間だけ表示）を
+            // 検証できる時間窓を確保する。即座に空ページを返すと、負荷の高い全体実行では
+            // スケルトンのカウント前に hasNextPage=false へ遷移して消えることがある。
+            await new Promise((resolve) => setTimeout(resolve, 500));
             // Return empty page for fetchMore
             return HttpResponse.json(createMockSearchableReservationsConnection([], false));
           }
@@ -579,24 +542,25 @@ describe("Reservation Page", () => {
         })
       );
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Wait for initial data to load
-      await waitFor(() => {
-        expect(screen.getByText("テスト文化センター0 音楽練習室A")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("テスト文化センター0 音楽練習室A")).toBeInTheDocument();
 
       // The skeleton loading row should appear because hasNextPage=true
-      const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
-      expect(skeletons.length).toBeGreaterThanOrEqual(1);
+      await vi.waitFor(() => {
+        expect(
+          document.querySelectorAll('[data-testid="skeleton"]').length
+        ).toBeGreaterThanOrEqual(1);
+      });
 
       // Wait for IntersectionObserver to fire and trigger fetchMore
       await new Promise((resolve) => setTimeout(resolve, 300));
 
       // Verify that fetchMore was called with the correct after cursor
-      await waitFor(
+      await vi.waitFor(
         () => {
           expect(requestCount).toBeGreaterThanOrEqual(2);
         },
@@ -628,14 +592,12 @@ describe("Reservation Page", () => {
 
       useMswMock(nodes, false);
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
       // Wait for initial data to load
-      await waitFor(() => {
-        expect(screen.getByText("施設0 練習室")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設0 練習室")).toBeInTheDocument();
 
       // With hasNextPage=false, no skeleton should appear
       const skeletons = document.querySelectorAll('[data-testid="skeleton"]');
@@ -685,16 +647,14 @@ describe("Reservation Page", () => {
 
       useMswMock([node1, node2]);
 
-      renderWithProviders(<ReservationPage />, {
+      await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("施設名")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("施設名")).toBeInTheDocument();
 
-      expect(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
-      expect(screen.getByText("サンプル会館 リハーサル室B")).toBeInTheDocument();
+      await expect.element(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
+      await expect.element(screen.getByText("サンプル会館 リハーサル室B")).toBeInTheDocument();
     });
 
     it("予約行はクリック可能で、クリック時にonRowClickが実行される", async () => {
@@ -713,18 +673,16 @@ describe("Reservation Page", () => {
 
       useMswMock([node]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("テスト文化センター 音楽練習室A")).toBeInTheDocument();
 
       // Verify the row has cursor pointer style (clickable via onRowClick)
       const cell = screen.getByText("テスト文化センター 音楽練習室A");
-      const row = cell.closest("tr");
-      expect(row).toHaveStyle({ cursor: "pointer" });
+      const row = cell.element().closest("tr");
+      await expect.element(row!).toHaveStyle({ cursor: "pointer" });
 
       // Click the row - this exercises the onRowClick handler
       await user.click(cell);
@@ -744,19 +702,17 @@ describe("Reservation Page", () => {
 
       useMswMock([node]);
 
-      const { user } = renderWithProviders(<ReservationPage />, {
+      const { user } = await renderWithProviders(<ReservationPage />, {
         initialEntries: ["/reservation?m=koutou"],
       });
 
-      await waitFor(() => {
-        expect(screen.getByText("テスト施設 音楽室")).toBeInTheDocument();
-      });
+      await expect.element(screen.getByText("テスト施設 音楽室")).toBeInTheDocument();
 
       // Click row with null institution.id - onRowClick short-circuits
       await user.click(screen.getByText("テスト施設 音楽室"));
 
       // Should still be on the same page (no navigation occurred)
-      expect(screen.getByText("テスト施設 音楽室")).toBeInTheDocument();
+      await expect.element(screen.getByText("テスト施設 音楽室")).toBeInTheDocument();
     });
   });
 });

--- a/packages/viewer/pages/Reservation.test.tsx
+++ b/packages/viewer/pages/Reservation.test.tsx
@@ -551,9 +551,9 @@ describe("Reservation Page", () => {
 
       // The skeleton loading row should appear because hasNextPage=true
       await vi.waitFor(() => {
-        expect(
-          document.querySelectorAll('[data-testid="skeleton"]').length
-        ).toBeGreaterThanOrEqual(1);
+        expect(document.querySelectorAll('[data-testid="skeleton"]').length).toBeGreaterThanOrEqual(
+          1
+        );
       });
 
       // Wait for IntersectionObserver to fire and trigger fetchMore

--- a/packages/viewer/pages/Top.test.tsx
+++ b/packages/viewer/pages/Top.test.tsx
@@ -4,57 +4,71 @@ import TopPage from "./Top";
 
 describe("Top Page", () => {
   describe("表示内容", () => {
-    it("メインの見出しを表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("メインの見出しを表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(screen.getByRole("heading", { name: "はじめに", level: 2 })).toBeInTheDocument();
-      expect(screen.getByRole("heading", { name: "機能の説明", level: 2 })).toBeInTheDocument();
-      expect(
-        screen.getByRole("heading", { name: "AI アシスタント連携", level: 2 })
-      ).toBeInTheDocument();
-      expect(screen.getByRole("heading", { name: "対応地区", level: 2 })).toBeInTheDocument();
-      expect(screen.getByRole("heading", { name: "備考", level: 2 })).toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "はじめに", level: 2 }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "機能の説明", level: 2 }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "AI アシスタント連携", level: 2 }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "対応地区", level: 2 }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "備考", level: 2 }))
+        .toBeInTheDocument();
     });
 
-    it("サブ見出しを表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("サブ見出しを表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByRole("heading", { name: "予約状況検索機能", level: 3 })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("heading", { name: "施設情報検索機能", level: 3 })
-      ).toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "予約状況検索機能", level: 3 }))
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByRole("heading", { name: "施設情報検索機能", level: 3 }))
+        .toBeInTheDocument();
     });
 
-    it("サイトの説明文を表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("サイトの説明文を表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByText(
-          "このサイトは音楽練習が可能な公共施設の予約状況・施設情報を閲覧するためのものです。"
+      await expect
+        .element(
+          screen.getByText(
+            "このサイトは音楽練習が可能な公共施設の予約状況・施設情報を閲覧するためのものです。"
+          )
         )
-      ).toBeInTheDocument();
+        .toBeInTheDocument();
     });
 
-    it("予約状況検索機能の説明を表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("予約状況検索機能の説明を表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByText("公共施設の予約状況を予約システムから取得し、加工して表示しています。")
-      ).toBeInTheDocument();
+      await expect
+        .element(
+          screen.getByText("公共施設の予約状況を予約システムから取得し、加工して表示しています。")
+        )
+        .toBeInTheDocument();
     });
 
-    it("施設情報検索機能の説明を表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("施設情報検索機能の説明を表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByText("公共施設の施設情報をウェブサイトから取得し、加工して表示しています。")
-      ).toBeInTheDocument();
+      await expect
+        .element(
+          screen.getByText("公共施設の施設情報をウェブサイトから取得し、加工して表示しています。")
+        )
+        .toBeInTheDocument();
     });
 
-    it("対応地区のリストを表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("対応地区のリストを表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
       const supportedAreas = [
         "荒川区",
@@ -70,62 +84,64 @@ describe("Top Page", () => {
         "川崎市",
       ];
 
-      supportedAreas.forEach((area) => {
-        expect(screen.getByText(area)).toBeInTheDocument();
-      });
+      for (const area of supportedAreas) {
+        await expect.element(screen.getByText(area)).toBeInTheDocument();
+      }
     });
 
-    it("備考の項目を表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("備考の項目を表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByText(
-          "予約状況検索機能については、管理人の許可制としております。管理人までご連絡ください。"
+      await expect
+        .element(
+          screen.getByText(
+            "予約状況検索機能については、管理人の許可制としております。管理人までご連絡ください。"
+          )
         )
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("表示されている情報に関し、当サイトはいかなる責任も負いません。")
-      ).toBeInTheDocument();
+        .toBeInTheDocument();
+      await expect
+        .element(screen.getByText("表示されている情報に関し、当サイトはいかなる責任も負いません。"))
+        .toBeInTheDocument();
     });
 
-    it("著作権表示を表示する", () => {
-      renderWithProviders(<TopPage />);
+    it("著作権表示を表示する", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(screen.getByText(/Copyright/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/Copyright/)).toBeInTheDocument();
     });
   });
 
   describe("セマンティック構造", () => {
-    it("適切なHTML構造を持つ", () => {
-      renderWithProviders(<TopPage />);
+    it("適切なHTML構造を持つ", async () => {
+      await renderWithProviders(<TopPage />);
 
       // メインランドマークが存在する
-      expect(screen.getByRole("main")).toBeInTheDocument();
+      await expect.element(screen.getByRole("main")).toBeInTheDocument();
 
       // リストが適切にマークアップされている
-      const lists = screen.getAllByRole("list");
+      const lists = screen.getByRole("list").all();
       expect(lists.length).toBeGreaterThan(0);
 
       // リストアイテムが存在する
-      const listItems = screen.getAllByRole("listitem");
+      const listItems = screen.getByRole("listitem").all();
       expect(listItems.length).toBeGreaterThan(0);
     });
 
-    it("見出しの階層構造が適切である", () => {
-      renderWithProviders(<TopPage />);
+    it("見出しの階層構造が適切である", async () => {
+      await renderWithProviders(<TopPage />);
 
       // h2見出しが存在する
-      const h2Headings = screen.getAllByRole("heading", { level: 2 });
+      const h2Headings = screen.getByRole("heading", { level: 2 }).all();
       expect(h2Headings).toHaveLength(5);
 
       // h3見出しが存在する
-      const h3Headings = screen.getAllByRole("heading", { level: 3 });
+      const h3Headings = screen.getByRole("heading", { level: 3 }).all();
       expect(h3Headings).toHaveLength(2);
     });
   });
 
   describe("レスポンシブ対応", () => {
-    it("モバイル表示で適切にレンダリングされる", () => {
+    it("モバイル表示で適切にレンダリングされる", async () => {
       // モバイルビューポートをシミュレート
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -133,14 +149,14 @@ describe("Top Page", () => {
         value: 375,
       });
 
-      const { container } = renderWithProviders(<TopPage />);
+      const { container } = await renderWithProviders(<TopPage />);
 
       // スタイルが適用されていることを確認
       const mainElement = container.querySelector("main");
-      expect(mainElement).toBeInTheDocument();
+      await expect.element(mainElement).toBeInTheDocument();
     });
 
-    it("デスクトップ表示で適切にレンダリングされる", () => {
+    it("デスクトップ表示で適切にレンダリングされる", async () => {
       // デスクトップビューポートをシミュレート
       Object.defineProperty(window, "innerWidth", {
         writable: true,
@@ -148,88 +164,91 @@ describe("Top Page", () => {
         value: 1024,
       });
 
-      const { container } = renderWithProviders(<TopPage />);
+      const { container } = await renderWithProviders(<TopPage />);
 
       // スタイルが適用されていることを確認
       const mainElement = container.querySelector("main");
-      expect(mainElement).toBeInTheDocument();
+      await expect.element(mainElement).toBeInTheDocument();
     });
   });
 
   describe("コンテンツの完全性", () => {
-    it("すべての必要な情報が含まれている", () => {
-      renderWithProviders(<TopPage />);
+    it("すべての必要な情報が含まれている", async () => {
+      await renderWithProviders(<TopPage />);
 
       // サイトの目的
-      expect(screen.getByText(/音楽練習が可能な公共施設/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/音楽練習が可能な公共施設/)).toBeInTheDocument();
 
       // 機能説明
-      expect(screen.getByText(/予約状況を予約システムから取得/)).toBeInTheDocument();
-      expect(screen.getByText(/施設情報をウェブサイトから取得/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/予約状況を予約システムから取得/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/施設情報をウェブサイトから取得/)).toBeInTheDocument();
 
       // AI アシスタント連携
-      expect(screen.getByText(/MCP サーバーのドキュメント/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/MCP サーバーのドキュメント/)).toBeInTheDocument();
 
       // 利用上の注意
-      expect(screen.getByText(/管理人の許可制/)).toBeInTheDocument();
-      expect(screen.getByText(/いかなる責任も負いません/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/管理人の許可制/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/いかなる責任も負いません/)).toBeInTheDocument();
     });
 
-    it("対応地区の情報が完全である", () => {
-      renderWithProviders(<TopPage />);
+    it("対応地区の情報が完全である", async () => {
+      await renderWithProviders(<TopPage />);
 
       // 対応地区の数をチェック - 対応地区のh2の次のulのliのみを数える
-      const areaHeading = screen.getByRole("heading", { name: "対応地区" });
+      const areaHeading = screen.getByRole("heading", { name: "対応地区" }).element();
       const nextSibling = areaHeading.nextElementSibling;
       const listItems = nextSibling?.querySelectorAll("li");
       expect(listItems).toHaveLength(11);
 
       // 予約状況表示不可の注記があることを確認
-      const unavailableAreas = screen.getAllByText(/※現在、予約状況が表示できません/);
+      const unavailableAreas = screen.getByText(/※現在、予約状況が表示できません/).all();
       expect(unavailableAreas).toHaveLength(1);
     });
   });
 
   describe("テキストの正確性", () => {
-    it("技術的な説明が正確である", () => {
-      renderWithProviders(<TopPage />);
+    it("技術的な説明が正確である", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByText("公共施設の予約状況を予約システムから取得し、加工して表示しています。")
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText("公共施設の施設情報をウェブサイトから取得し、加工して表示しています。")
-      ).toBeInTheDocument();
+      await expect
+        .element(
+          screen.getByText("公共施設の予約状況を予約システムから取得し、加工して表示しています。")
+        )
+        .toBeInTheDocument();
+      await expect
+        .element(
+          screen.getByText("公共施設の施設情報をウェブサイトから取得し、加工して表示しています。")
+        )
+        .toBeInTheDocument();
     });
 
-    it("免責事項が適切に表示されている", () => {
-      renderWithProviders(<TopPage />);
+    it("免責事項が適切に表示されている", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(
-        screen.getByText("表示されている情報に関し、当サイトはいかなる責任も負いません。")
-      ).toBeInTheDocument();
+      await expect
+        .element(screen.getByText("表示されている情報に関し、当サイトはいかなる責任も負いません。"))
+        .toBeInTheDocument();
     });
 
-    it("著作権情報が正確である", () => {
-      renderWithProviders(<TopPage />);
+    it("著作権情報が正確である", async () => {
+      await renderWithProviders(<TopPage />);
 
-      expect(screen.getByText(/Copyright/)).toBeInTheDocument();
+      await expect.element(screen.getByText(/Copyright/)).toBeInTheDocument();
     });
   });
 
   describe("スタイリング", () => {
-    it("コンテナの最大幅が設定されている", () => {
-      const { container } = renderWithProviders(<TopPage />);
+    it("コンテナの最大幅が設定されている", async () => {
+      const { container } = await renderWithProviders(<TopPage />);
 
-      const contentBox = container.querySelector('[class*="contentBox"]');
-      expect(contentBox).toBeInTheDocument();
+      const contentBox = container.querySelector<HTMLElement>('[class*="contentBox"]');
+      await expect.element(contentBox).toBeInTheDocument();
     });
 
-    it("著作権セクションが中央揃えで表示される", () => {
-      renderWithProviders(<TopPage />);
+    it("著作権セクションが中央揃えで表示される", async () => {
+      await renderWithProviders(<TopPage />);
 
-      const copyright = screen.getByText(/Copyright/);
-      expect(copyright).toBeInTheDocument();
+      await expect.element(screen.getByText(/Copyright/)).toBeInTheDocument();
     });
   });
 });

--- a/packages/viewer/pages/Waiting.test.tsx
+++ b/packages/viewer/pages/Waiting.test.tsx
@@ -3,23 +3,23 @@ import { renderWithProviders, screen } from "../test/utils/test-utils";
 import WaitingPage from "./Waiting";
 
 describe("Waiting Page", () => {
-  it("isLoading=trueの場合、Loadingコンポーネント（Spinner）を表示する", () => {
-    renderWithProviders(<WaitingPage />, {
+  it("isLoading=trueの場合、Loadingコンポーネント（Spinner）を表示する", async () => {
+    await renderWithProviders(<WaitingPage />, {
       auth0Config: { isLoading: true },
     });
 
     const spinner = screen.getByRole("progressbar");
-    expect(spinner).toBeInTheDocument();
+    await expect.element(spinner).toBeInTheDocument();
   });
 
-  it("isLoading=falseの場合、トップページにリダイレクトする", () => {
-    renderWithProviders(<WaitingPage />, {
+  it("isLoading=falseの場合、トップページにリダイレクトする", async () => {
+    await renderWithProviders(<WaitingPage />, {
       initialEntries: ["/waiting"],
       route: "/waiting",
       auth0Config: { isLoading: false },
     });
 
     // Navigate to "/" means no progressbar should be visible
-    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    await expect.element(screen.getByRole("progressbar")).not.toBeInTheDocument();
   });
 });

--- a/packages/viewer/test/browser-setup.ts
+++ b/packages/viewer/test/browser-setup.ts
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { afterEach, beforeAll, afterAll, vi } from "vitest";
-import { cleanup } from "@testing-library/react";
-import "@testing-library/jest-dom/vitest";
 
 // Mock @auth0/auth0-spa-js to prevent it from interfering with React module resolution
 vi.mock("@auth0/auth0-spa-js", () => ({
@@ -95,9 +93,8 @@ beforeAll(async () => {
   };
 });
 
-// Clean up after each test
+// Clean up after each test (unmount 自体は vitest-browser-react が自動で行う)
 afterEach(() => {
-  cleanup();
   if (worker) {
     worker.resetHandlers();
   }

--- a/packages/viewer/test/integration/authFlow.test.tsx
+++ b/packages/viewer/test/integration/authFlow.test.tsx
@@ -4,26 +4,26 @@ import { AuthGuard } from "../../components/utils/AuthGuard";
 
 describe("Authentication Flow", () => {
   describe("AuthGuard", () => {
-    it("匿名ユーザーの場合、保護されたコンテンツを表示しない", () => {
-      renderWithProviders(<AuthGuard Component={<div>Protected Content</div>} />, {
+    it("匿名ユーザーの場合、保護されたコンテンツを表示しない", async () => {
+      await renderWithProviders(<AuthGuard Component={<div>Protected Content</div>} />, {
         auth0Config: {
           isLoading: false,
           userInfo: { anonymous: true, trial: false },
         },
       });
 
-      expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+      await expect.element(screen.getByText("Protected Content")).not.toBeInTheDocument();
     });
 
-    it("認証済みユーザーの場合、保護されたコンテンツを表示する", () => {
-      renderWithProviders(<AuthGuard Component={<div>Protected Content</div>} />, {
+    it("認証済みユーザーの場合、保護されたコンテンツを表示する", async () => {
+      await renderWithProviders(<AuthGuard Component={<div>Protected Content</div>} />, {
         auth0Config: {
           isLoading: false,
           userInfo: { anonymous: false, trial: false },
         },
       });
 
-      expect(screen.getByText("Protected Content")).toBeInTheDocument();
+      await expect.element(screen.getByText("Protected Content")).toBeInTheDocument();
     });
   });
 });

--- a/packages/viewer/test/integration/navigation.test.tsx
+++ b/packages/viewer/test/integration/navigation.test.tsx
@@ -5,25 +5,25 @@ import Waiting from "../../pages/Waiting";
 
 describe("Navigation", () => {
   describe("Detail page", () => {
-    it("無効なUUIDの場合、トップページにリダイレクトする", () => {
+    it("無効なUUIDの場合、トップページにリダイレクトする", async () => {
       // When an invalid UUID is provided, Detail renders <Navigate to="/" />.
       // Since MemoryRouter uses route="/*" catch-all, we add a "/" route
       // to verify the redirect happened by checking the Detail content is absent.
-      renderWithProviders(<Detail />, {
+      await renderWithProviders(<Detail />, {
         route: "/institution/:id",
         initialEntries: ["/institution/invalid-uuid"],
       });
 
       // The Detail page content should not be rendered because it redirects.
       // The component renders Navigate to "/" so no institution detail elements appear.
-      expect(screen.queryByRole("tab", { name: "施設情報" })).not.toBeInTheDocument();
-      expect(screen.queryByRole("tab", { name: "予約状況" })).not.toBeInTheDocument();
+      await expect.element(screen.getByRole("tab", { name: "施設情報" })).not.toBeInTheDocument();
+      await expect.element(screen.getByRole("tab", { name: "予約状況" })).not.toBeInTheDocument();
     });
   });
 
   describe("Waiting page", () => {
-    it("認証ロード完了後、トップページにリダイレクトする", () => {
-      renderWithProviders(<Waiting />, {
+    it("認証ロード完了後、トップページにリダイレクトする", async () => {
+      await renderWithProviders(<Waiting />, {
         route: "/waiting",
         initialEntries: ["/waiting"],
         auth0Config: {
@@ -33,11 +33,11 @@ describe("Navigation", () => {
 
       // When isLoading is false, Waiting renders <Navigate to="/" />.
       // The spinner should not be present since we are redirecting.
-      expect(screen.queryByLabelText("読み込み中")).not.toBeInTheDocument();
+      await expect.element(screen.getByLabelText("読み込み中")).not.toBeInTheDocument();
     });
 
-    it("認証ロード中の場合、ローディングスピナーを表示する", () => {
-      renderWithProviders(<Waiting />, {
+    it("認証ロード中の場合、ローディングスピナーを表示する", async () => {
+      await renderWithProviders(<Waiting />, {
         route: "/waiting",
         initialEntries: ["/waiting"],
         auth0Config: {
@@ -45,7 +45,7 @@ describe("Navigation", () => {
         },
       });
 
-      expect(screen.getByLabelText("読み込み中")).toBeInTheDocument();
+      await expect.element(screen.getByLabelText("読み込み中")).toBeInTheDocument();
     });
   });
 });

--- a/packages/viewer/test/utils/test-utils.tsx
+++ b/packages/viewer/test/utils/test-utils.tsx
@@ -1,8 +1,8 @@
-import { render } from "@testing-library/react";
+import { render } from "vitest-browser-react";
 import { ReactElement, ReactNode } from "react";
 import { Route, Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
-import { userEvent as browserUserEvent } from "@vitest/browser/context";
+import { page, userEvent as browserUserEvent } from "vitest/browser";
 import { vi } from "vitest";
 import { Auth0Context } from "../../contexts/Auth0";
 
@@ -37,9 +37,9 @@ interface CustomRenderOptions {
   auth0Config?: Auth0MockConfig;
 }
 
-export function renderWithProviders(
+export async function renderWithProviders(
   ui: ReactElement,
-  { initialEntries = ["/"], route, auth0Config = {}, ...renderOptions }: CustomRenderOptions = {}
+  { initialEntries = ["/"], route, auth0Config = {} }: CustomRenderOptions = {}
 ) {
   // Use browser's native userEvent
   const user = browserUserEvent;
@@ -57,11 +57,16 @@ export function renderWithProviders(
     );
   }
 
+  const result = await render(ui, { wrapper: Wrapper });
+
   return {
     user,
-    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    ...result,
   };
 }
 
-// Re-export everything from testing library
-export * from "@testing-library/react";
+// ページ全体を対象とする locator セレクタ。Testing Library の `screen` の後継。
+// getBy* は Locator を返す（遅延評価・自動リトライ）。queryBy*/findBy*/getAllBy* は
+// 存在しないため、不在アサーションは expect.element(...).not.toBeInTheDocument()、
+// 複数要素は getBy*(...).all() を使う。
+export const screen = page;


### PR DESCRIPTION
## 概要

ライブラリモダン化の第4弾（A-2）。viewer は Vitest 4 browser mode（実 Chromium / Playwright provider）で動いているのに、テスト API だけ旧世代の @testing-library/react + jest-dom を使っていた。Vitest 公式推奨の vitest-browser-react v2（locator ベース・リトライ内蔵）へ全面移行する。

**40 テストファイル / 555 テスト、全 pass。**

## 主な変換

- `renderWithProviders()` は async 化（vitest-browser-react の `render` が `Promise<RenderResult>` を返すため）。`screen` は `page`（locator セレクタ）の再輸出に
- assertion は `await expect.element(...)` 形式へ（jest-dom マッチャー相当は組み込み）
- `queryBy*`/`findBy*` は `getBy*` locator に統一（locator は遅延評価で throw しないため、不在確認は `.not.toBeInTheDocument()`、自動リトライで findBy 相当）
- `getAllBy*` → `.all()`、DOM 直接アクセス（`.textContent`/`.closest()`）は `.element()` 経由
- `fireEvent.change` → `user.fill()` / `user.selectOptions()`（合成イベントから実ブラウザ操作へ）
- **Playwright locator の `getByText` は部分一致がデフォルト**（RTL は完全一致）。"東京" が "東京-100" にもマッチする等の衝突箇所は `{ exact: true }` で完全一致を復元
- deprecated な `@vitest/browser/context` import を `vitest/browser` へ
- fetchMore テストの skeleton 検証にタイミング競合があったため、fetchMore 応答に遅延窓を設けて安定化（検証意図は不変）
- viewer CLAUDE.md の Testing 記述を更新

## 削除された依存

- `@testing-library/react` 16.3.2
- `@testing-library/jest-dom` 6.9.1
- `@vitest/browser`（`@vitest/browser-playwright` が依存として引き込むため直接宣言は不要）

追加: `vitest-browser-react` 2.2.0 のみ

## 検証

- viewer unit: **555 tests / 56 files 全 pass** ✅
- `npm run typecheck:all` ✅
- `npm run lint`（viewer 全体、max-warnings=0）✅
- `npm run knip` ✅
- Prettier 適用済み ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)