### PR TITLE
fix(mcp-server): GET /mcp を 405 で弾き KV read の暴走を止める

### DIFF
--- a/packages/mcp-server/preflight.test.ts
+++ b/packages/mcp-server/preflight.test.ts
@@ -1,0 +1,86 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { describe, expect, it } from "vitest";
+
+import { preflight } from "./preflight.ts";
+
+const req = (method: string, path: string, headers: Record<string, string> = {}) =>
+  new Request(`https://mcp.example.com${path}`, { method, headers });
+
+describe("preflight", () => {
+  it("未知のパスを 404 で短絡する", () => {
+    const res = preflight(req("GET", "/wp-login.php"));
+    expect(res?.status).toBe(404);
+  });
+
+  it("既知のパスは通す", () => {
+    expect(preflight(req("GET", "/authorize"))).toBeNull();
+    expect(preflight(req("POST", "/oauth/token"))).toBeNull();
+    expect(preflight(req("POST", "/mcp"))).toBeNull();
+  });
+
+  it("形式不正な Bearer トークンを 401 で短絡する", () => {
+    const res = preflight(req("POST", "/mcp", { authorization: "Bearer garbage" }));
+    expect(res?.status).toBe(401);
+  });
+
+  it("OAuthProvider 形式のトークンは通す", () => {
+    const res = preflight(req("POST", "/mcp", { authorization: "Bearer user:grant:hash" }));
+    expect(res).toBeNull();
+  });
+
+  it("GET /mcp を 405 で短絡する（ステートレスなので SSE ストリームを提供しない）", () => {
+    const res = preflight(
+      req("GET", "/mcp", {
+        accept: "text/event-stream",
+        authorization: "Bearer user:grant:hash",
+      })
+    );
+    expect(res?.status).toBe(405);
+    expect(res?.headers.get("allow")).toBe("POST");
+  });
+
+  // DELETE はステートレスでも 200 を返して正常終了する（ハングしない）ため短絡しない
+  it("DELETE /mcp は通す", () => {
+    const res = preflight(req("DELETE", "/mcp", { authorization: "Bearer user:grant:hash" }));
+    expect(res).toBeNull();
+  });
+
+  it("GET /mcp の 405 は JSON-RPC エラー本文を返す", async () => {
+    const res = preflight(req("GET", "/mcp", { accept: "text/event-stream" }));
+    expect(res).not.toBeNull();
+    const body = (await res!.json()) as { error: { code: number } };
+    expect(body.error.code).toBe(-32000);
+  });
+});
+
+/**
+ * preflight が GET を弾く根拠を固定する。worker.ts はリクエストごとに transport を作り直す
+ * ステートレス構成なので、GET が開く SSE ストリームには誰も書き込まない。Workers ランタイムは
+ * これをハングと判定してリクエストを落とし、クライアントが再接続ループに入る。
+ * SDK 側の挙動が変わったらこのテストが落ちて気づける。
+ */
+describe("WebStandardStreamableHTTPServerTransport の GET 挙動", () => {
+  it("ステートレス構成の GET は、決して書き込まれない SSE ストリームを返す", async () => {
+    const transport = new WebStandardStreamableHTTPServerTransport({});
+    const res = await transport.handleRequest(
+      new Request("https://mcp.example.com/mcp", {
+        method: "GET",
+        headers: { accept: "text/event-stream" },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = res.body!.getReader();
+    const silent = Symbol("silent");
+    const outcome = await Promise.race([
+      reader.read(),
+      new Promise((resolve) => setTimeout(() => resolve(silent), 200)),
+    ]);
+
+    // チャンクも終端も来ない = ランタイムから見て「応答を生成しえない」状態
+    expect(outcome).toBe(silent);
+    await reader.cancel();
+  });
+});

--- a/packages/mcp-server/preflight.ts
+++ b/packages/mcp-server/preflight.ts
@@ -1,0 +1,71 @@
+/**
+ * OAuthProvider に渡す前のリクエスト短絡判定。
+ *
+ * OAuthProvider はハンドラを呼ぶ前に必ずトークンを KV から引く。つまり OAuthProvider に
+ * 到達した時点で KV read が 1 回確定する。ここで先に弾けるものを弾くことで read を節約する。
+ *
+ * 短絡すべきリクエストには Response を、通すべきリクエストには null を返す。
+ */
+
+const ALLOWED_PATHS = new Set([
+  "/mcp",
+  "/authorize",
+  "/callback",
+  "/oauth/token",
+  "/oauth/register",
+  "/.well-known/oauth-authorization-server",
+  "/.well-known/oauth-protected-resource",
+]);
+
+/**
+ * OAuthProvider issues tokens in `userId:grantId:hash` format (3 colon-separated parts).
+ * Reject tokens that don't match this format before OAuthProvider attempts a KV read.
+ */
+function hasValidInternalTokenFormat(authHeader: string): boolean {
+  if (!authHeader.startsWith("Bearer ")) return true; // no Bearer → let OAuthProvider return 401
+  const token = authHeader.substring(7);
+  return token.split(":").length === 3;
+}
+
+function jsonRpcError(status: number, message: string, headers: HeadersInit): Response {
+  return Response.json(
+    { jsonrpc: "2.0", error: { code: -32000, message }, id: null },
+    { status, headers }
+  );
+}
+
+export function preflight(request: Request): Response | null {
+  const url = new URL(request.url);
+
+  // 1. 未知のパスを弾く（脆弱性スキャナの巡回など）
+  if (!ALLOWED_PATHS.has(url.pathname)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  if (url.pathname !== "/mcp") return null;
+
+  // 2. OAuthProvider 形式に合わないトークンを弾く
+  const authHeader = request.headers.get("authorization");
+  if (authHeader && !hasValidInternalTokenFormat(authHeader)) {
+    return Response.json(
+      { error: "invalid_token", error_description: "Invalid token format" },
+      { status: 401, headers: { "WWW-Authenticate": 'Bearer error="invalid_token"' } }
+    );
+  }
+
+  // 3. GET（サーバー発通知用の SSE ストリーム開設）を弾く。
+  //    このサーバーはリクエストごとに transport を作り直すステートレス構成で、
+  //    sessionIdGenerator を持たない。よって GET が開いたストリームに書き込む主体が
+  //    存在せず、SDK が返す ReadableStream は永久に無音のままになる。Workers ランタイムは
+  //    これを「応答を生成しえないハング」と判定してリクエストを強制終了し、クライアントは
+  //    即座に再接続する。この再接続ループが 1 回ごとに KV read を焼く。
+  //    MCP 仕様は SSE ストリームを提供しないサーバーが 405 を返すことを認めており、
+  //    クライアントは 405 を受けると再接続せず静かに諦める。
+  if (request.method === "GET") {
+    return jsonRpcError(405, "Method Not Allowed: this server does not offer an SSE stream", {
+      Allow: "POST",
+    });
+  }
+
+  return null;
+}

--- a/packages/mcp-server/worker.ts
+++ b/packages/mcp-server/worker.ts
@@ -8,6 +8,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { resolveRole } from "@shisetsu-viewer/api/auth/auth0";
 
 import { createD1DataSource } from "./d1DataSource.ts";
+import { preflight } from "./preflight.ts";
 import { createServer } from "./server.ts";
 
 interface Env {
@@ -216,55 +217,14 @@ function createOAuthProvider(env: Env) {
 }
 
 // ---------------------------------------------------------------------------
-// Request pre-filtering (prevents unnecessary KV reads from OAuthProvider)
-// ---------------------------------------------------------------------------
-
-const ALLOWED_PATHS = new Set([
-  "/mcp",
-  "/authorize",
-  "/callback",
-  "/oauth/token",
-  "/oauth/register",
-  "/.well-known/oauth-authorization-server",
-  "/.well-known/oauth-protected-resource",
-]);
-
-/**
- * OAuthProvider issues tokens in `userId:grantId:hash` format (3 colon-separated parts).
- * Reject tokens that don't match this format before OAuthProvider attempts a KV read.
- */
-function hasValidInternalTokenFormat(authHeader: string): boolean {
-  if (!authHeader.startsWith("Bearer ")) return true; // no Bearer → let OAuthProvider return 401
-  const token = authHeader.substring(7);
-  return token.split(":").length === 3;
-}
-
-// ---------------------------------------------------------------------------
 // Worker entry point
 // ---------------------------------------------------------------------------
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const url = new URL(request.url);
-
-    // 1a. Reject unknown paths before OAuthProvider
-    if (!ALLOWED_PATHS.has(url.pathname)) {
-      return new Response("Not Found", { status: 404 });
-    }
-
-    // 1b. Reject malformed Bearer tokens on /mcp to avoid KV reads
-    if (url.pathname === "/mcp") {
-      const authHeader = request.headers.get("authorization");
-      if (authHeader && !hasValidInternalTokenFormat(authHeader)) {
-        return Response.json(
-          { error: "invalid_token", error_description: "Invalid token format" },
-          {
-            status: 401,
-            headers: { "WWW-Authenticate": 'Bearer error="invalid_token"' },
-          }
-        );
-      }
-    }
+    // OAuthProvider はハンドラを呼ぶ前にトークンを KV から引くため、弾けるものは先に弾く
+    const shortCircuit = preflight(request);
+    if (shortCircuit) return shortCircuit;
 
     return createOAuthProvider(env).fetch(request, env, ctx);
   },


### PR DESCRIPTION
## 背景

Cloudflare KV の daily usage 50% アラートが頻発していた。原因を調査したところ、利用増加ではなく **`GET /mcp` の無限リトライループ**だった。

## 根本原因

`worker.ts` はリクエストごとに transport を作り直すステートレス構成で、`sessionIdGenerator` を持たない。この状態で `GET /mcp` が来ると SDK の `handleGetRequest` は「サーバー発通知用の SSE ストリーム」を開くが、**書き込む主体が存在しない**ため永久に無音のままになる。

Workers ランタイムはこれを「応答を生成しえないハング」と判定してリクエストを強制終了し、クライアントは即座に再接続する。

OAuthProvider はハンドラを呼ぶ前に必ずトークンを KV から引くため、**この再接続 1 回ごとに KV read が 1 回焼かれていた**。

## 実測データ（本番）

Worker invocations（2026-07-23〜25 の 3 日間）:

| 指標 | 値 |
|---|---|
| 総リクエスト | 124,585 |
| `scriptThrewException` | **123,616（99.2%）** |
| `success` | 594 |

例外は全て `The Workers runtime canceled this request because it detected that your Worker's code had hung and would never generate a response.`

直近 6 時間のトリガ内訳:

| トリガ | 件数 |
|---|---|
| `GET /mcp` | **54,800** |
| `POST /oauth/token` | 600 |
| `POST /mcp` | 100 |

KV 操作:

| 日付 | read | write |
|---|---|---|
| 7/18 | **70,070** | 140 |
| 7/19 | **66,930** | 50 |
| 7/24 | **63,830** | 170 |
| 7/23 | **49,550** | 260 |
| 7/12〜7/17 の多く | 20〜30 | 0 |

無料枠の read は 100,000/日。50%（50,000）を超えた日にアラートが鳴っていた。write は最大 260/日で無風のため、**read 単独の問題**。

## 修正

- 短絡判定を `preflight.ts` へ切り出し（既存の「未知パス 404」「不正トークン 401」も集約）
- `GET /mcp` を **405 + `Allow: POST`** で返す
- MCP 仕様は SSE ストリームを提供しないサーバーが 405 を返すことを認めている。SDK のクライアントは 405 を受けると**再接続せず静かに諦める**（`client/streamableHttp.js`: `if (response.status === 405) return;`）
- 405 は OAuthProvider に到達する前に返るため、**KV read が発生しない**

`DELETE /mcp` はステートレスでも 200 を返して正常終了しハングしないため対象外とした（ログ上も件数ゼロ）。

## 検証

ユニットテスト 24 件通過。うち新規 8 件:

- `preflight` の各分岐（405 / 404 / 401 / 通過）
- **根本原因の回帰テスト**: ステートレス構成の transport に GET を渡すと、200ms 待ってもチャンクも終端も来ない無音ストリームが返ることを固定。SDK 側の挙動が変わったら落ちて気づける

`wrangler dev` による実地確認:

| リクエスト | 結果 | 時間 |
|---|---|---|
| `GET /mcp` | 405 `Allow: POST` | 34ms（ハングせず即返る） |
| `POST /mcp` | 401（OAuthProvider へ通過して判定） | 12ms |
| `GET /wp-login.php` | 404 | 2ms |
| `POST /mcp` 不正トークン | 401 | 2ms |

typecheck / oxlint / oxfmt 通過。

## デプロイ後に見るべきもの

- KV read が日次 1,000 未満程度まで落ちること
- `scriptThrewException` が消えること
- `POST /oauth/token` の頻度（6h で約 300 リクエスト相当）。GET ループの副作用で再認証が誘発されていた可能性があり、収まらなければ別途調査する

🤖 Generated with [Claude Code](https://claude.com/claude-code)