### PR TITLE
docs: mcp-server と root の CLAUDE.md を D1 直バインドの実態に合わせる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,5 +32,5 @@ Shisetsu Viewer is a web application for viewing public facility reservation sta
 ## Cross-Package Architecture
 
 - `@shisetsu-viewer/shared` の `registry.ts` / `types.ts` が自治体データと enum の source of truth。viewer / scraper 双方が import する。
-- Data flow: scrapers が自治体サイトを巡回 → 変換 → Hasura GraphQL へ upload（Auth0 M2M token）。viewer は自作 fetch ベース GraphQL client で取得（Auth0 Bearer token）。
-- MCP server は同データを AI 向けに公開（Workers デプロイは read-only、local stdio は write 可）。
+- Data flow: scrapers が自治体サイトを巡回 → 変換 → **Hasura（Auth0 M2M）と `packages/api`（GitHub OIDC）へ dual-write**。読み取りはすでに D1 側へ切替済みで、viewer は `packages/api` の REST を叩く（Auth0 Bearer token）。Hasura は PR 3-5 で撤去する。
+- MCP server は同データを AI 向けに公開（Workers デプロイは D1 直バインドで read-only、local stdio は api 経由で write 可）。

--- a/packages/mcp-server/CLAUDE.md
+++ b/packages/mcp-server/CLAUDE.md
@@ -1,19 +1,24 @@
 # MCP Server Package
 
-Hasura のデータを AI 向けツールとして公開する MCP サーバー。Deps: `@modelcontextprotocol/sdk`, `zod`, `@cloudflare/workers-oauth-provider`。Commands: see `package.json` scripts (`typecheck`, `deploy`, `preview:wrangler`, `start` = local stdio, `cli`).
+施設・予約データを AI 向けツールとして公開する MCP サーバー。Deps: `@modelcontextprotocol/sdk`, `zod`, `@cloudflare/workers-oauth-provider`。Commands: see `package.json` scripts (`typecheck`, `test`, `deploy`, `preview:wrangler`, `start` = local stdio, `cli`).
 
 ## Entry Points と認証モード
 
-| Entry       | 用途                                  | クライアント認証                                                                        | Hasura への認証                                  | Write tools |
+| Entry       | 用途                                  | クライアント認証                                                                        | データ経路                                       | Write tools |
 | ----------- | ------------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------- |
-| `worker.ts` | Cloudflare Workers デプロイ           | MCP OAuth（Auth0 + Dynamic Client Registration、トークンは KV `OAUTH_KV` に暗号化保存） | ユーザーの Auth0 トークンを転送（per-user 権限） | 無効        |
-| `index.ts`  | local stdio（dev/debug）              | なし                                                                                    | Auth0 M2M                                        | 有効        |
-| `cli.ts`    | shell から JSON 取得（AI agent 向け） | Auth0 Authorization Code + PKCE（`~/.config/shisetsu/tokens.json`、自動リフレッシュ）   | 同トークン転送                                   | —           |
+| `worker.ts` | Cloudflare Workers デプロイ           | MCP OAuth（Auth0 + Dynamic Client Registration、トークンは KV `OAUTH_KV` に暗号化保存） | D1 直バインド `env.DB`                           | 無効        |
+| `index.ts`  | local stdio（dev/debug）              | なし                                                                                    | `packages/api` へ HTTP + `X-Admin-Key`           | 有効        |
+| `cli.ts`    | shell から JSON 取得（AI agent 向け） | Auth0 Authorization Code + PKCE（`~/.config/shisetsu/tokens.json`、自動リフレッシュ）   | `packages/api` へ HTTP + Bearer 転送             | —           |
 
-- **罠**: GraphQL クライアントは `createGraphQLClient(endpoint, token)` でリクエストごとに生成し、`createServer({ client })` 経由でツールへ渡す。トークンをモジュールスコープに置くと、Workers の isolate が `await` を跨いで並行リクエストの値に差し替えるため、ユーザー間でトークンが混線する（stdio では 1 プロセス 1 ユーザーなので顕在化しない）。
-- Tools: read = `listInstitutions` / `getInstitutionDetail` / `getInstitutionReservations` / `searchReservations`、write = `upsertReservations` / `upsertInstitutions`。Resource: `municipalities`（shared registry）。
+- **データ境界は `DataSource` インターフェース**（`dataSource.ts`）。`createD1DataSource(db)` は `@shisetsu-viewer/api/db/queries` の純関数へ D1 binding で委譲する薄いラッパ、`createHttpDataSource(endpoint, auth)` は同じ形を REST で満たす。ツール実装はどちらかを知らない。
+- **罠**: `DataSource` と role はリクエストごとに生成して `createServer({ dataSource, allowReservations })` へ注入する。モジュールスコープに置くと、Workers の isolate が `await` を跨いで並行リクエストの値に差し替えるため、ユーザー間で認証状態が混線する（stdio では 1 プロセス 1 ユーザーなので顕在化しない）。
+- worker は `resolveRole(upstreamAccessToken, env)` を per-request に呼び、`role === "user"` のときだけ reservations 系ツールを露出する（`allowReservations`）。**trial ユーザーは anonymous 扱い**で、現行 viewer の UI ゲートと同義。
+- Tools: 常時 = `listInstitutions` / `getInstitutionDetail`、`allowReservations` 時のみ = `getInstitutionReservations` / `searchReservations`、`write` 注入時のみ = `upsertReservations` / `upsertInstitutions`。Resource: `municipalities`（shared registry）。Prompts: `guide` / `searchAvailableRooms`。
+- `getInstitutionReservations` の取得上限は `RESERVATIONS_HARD_CAP`（1000）。D1 側は 100 件ずつカーソルで回して詰める。
 - CLI 例: `npm run cli -w @shisetsu-viewer/mcp-server -- search --start-date 2026-03-15 --end-date 2026-03-31 --evening`（`login` / `logout` / `--help` あり）。
 
 ## Environment
 
-local stdio は `.env`（`GRAPHQL_ENDPOINT`, `AUTH0_*` は M2M app の値）。Workers は wrangler secrets（同名だが Auth0 は Regular Web App の値）+ KV binding `OAUTH_KV`。
+- **Workers**: wrangler secrets `AUTH0_DOMAIN` / `AUTH0_CLIENT_ID` / `AUTH0_CLIENT_SECRET` / `AUTH0_AUDIENCE`（Auth0 Regular Web App の値）+ KV binding `OAUTH_KV` + D1 binding `DB`（`shisetsu-db`、api と同一 DB）。Workers Builds 未接続のため `npm run deploy -w @shisetsu-viewer/mcp-server` で手動デプロイする。
+- **local stdio**: `.env` の `API_ENDPOINT` と `ADMIN_API_KEY`（`env.ts` がどちらも必須として throw する）。
+- **cli**: `API_ENDPOINT` + Auth0 PKCE で取得したユーザートークン。


### PR DESCRIPTION
## 背景

PR #1653 で mcp-server は Hasura GraphQL クライアント注入から **D1 直バインド + `DataSource` の per-request DI** へ変わったが、`packages/mcp-server/CLAUDE.md` が旧構成のまま残っていた。

とくに以下は「既に存在しないもの」を罠として指しており、次に読むエージェントを誤らせる:

> GraphQL クライアントは `createGraphQLClient(endpoint, token)` でリクエストごとに生成し、`createServer({ client })` 経由でツールへ渡す。

root の `CLAUDE.md` も「viewer は自作 fetch ベース GraphQL client で取得」のままで、PR #1652 の REST 化が反映されていなかった。

## 変更

### `packages/mcp-server/CLAUDE.md`

- 3 エントリのデータ経路を実態に更新
  - `worker.ts` → D1 直バインド `env.DB`
  - `index.ts`（stdio） → `packages/api` へ HTTP + `X-Admin-Key`
  - `cli.ts` → `packages/api` へ HTTP + Bearer 転送
- `DataSource` インターフェースがデータ境界であること、混線の罠が「トークン」から「DataSource と role」に移ったことを記載
- `resolveRole` の per-request 解決と **trial ユーザーは anonymous 扱い**を追記
- ツールの露出条件を「常時 / `allowReservations` 時 / `write` 注入時」の 3 段で明示。prompts (`guide` / `searchAvailableRooms`) を追加
- `RESERVATIONS_HARD_CAP`（1000、D1 側は 100 件ずつカーソル）を追記
- Environment を Workers / stdio / cli の 3 つに分け、`API_ENDPOINT` + `ADMIN_API_KEY`（`env.ts` が必須 throw）と D1 binding を明記

### `CLAUDE.md`

- Data flow を「scrapers が Hasura と `packages/api` へ dual-write、読み取りは D1 側へ切替済み、Hasura は PR 3-5 で撤去」に更新

## 検証

`npm run format:check:all` ✅（ドキュメントのみの変更でコード差分なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)