### PR TITLE
perf(api): 予約 export を PK 順 keyset にして D1 読み取り無料枠の超過を解消する

### DIFF
--- a/packages/api/src/db/queries.ts
+++ b/packages/api/src/db/queries.ts
@@ -4,6 +4,7 @@ import type {
   InstitutionsQueryParams,
   Page,
   ReservationDto,
+  ReservationExportRow,
   ReservationSearchHit,
   ReservationSearchQueryParams,
   ScrapeRun,
@@ -14,6 +15,9 @@ import { decodeCursor, encodeCursor } from "./cursor.ts";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
+// export だけ上限が別なのは、PK 順の走査でページサイズ分しか行を読まないため
+// （search 系は ORDER BY が全件ソートを誘発しうるので 100 に据え置く）。
+const MAX_EXPORT_LIMIT = 1000;
 const AVAILABLE = "AVAILABILITY_DIVISION_AVAILABLE";
 
 function clampLimit(limit: number | undefined): number {
@@ -396,6 +400,65 @@ export async function searchReservations(
       endCursor:
         hasNextPage && last
           ? encodeCursor({ date: last.date, institution_id: last.institution_id })
+          : null,
+    },
+  };
+}
+
+/**
+ * parity 突合用の全行 dump。
+ *
+ * ORDER BY を PK (institution_id, date) に揃えるのが要点。searchReservations と同じ
+ * (date, institution_id) 順にすると `WITHOUT ROWID` の物理順と食い違い、SQLite は
+ * ページごとに候補全件を一時 B-tree でソートする。keyset カーソルは WHERE でしか
+ * 効かないので走査量が減らず、コストが O(N^2 / page) に膨らむ
+ * （実測: 豊島区 8,928 行の 101 行ページで 7,073 行読み。全自治体 1 巡で約 500 万行）。
+ *
+ * municipality での絞り込みも行わない。institutions と JOIN した時点で institutions
+ * 駆動の計画になり、同じ全件ソートが復活するため。呼び出し側が institution_id →
+ * municipality のマップで分類する。
+ */
+export async function exportReservations(
+  db: D1Database,
+  params: { limit?: number | undefined; cursor?: string | undefined }
+): Promise<Page<ReservationExportRow>> {
+  const requested = params.limit && params.limit > 0 ? params.limit : MAX_EXPORT_LIMIT;
+  const limit = Math.min(requested, MAX_EXPORT_LIMIT);
+  const args: unknown[] = [];
+  let where = "";
+  if (params.cursor) {
+    const c = decodeCursor(params.cursor);
+    if (c) {
+      where = `WHERE (institution_id, date) > (?, ?)`;
+      args.push(c["institution_id"], c["date"]);
+    }
+  }
+  const sql = `
+    SELECT institution_id, date, reservation
+    FROM reservations
+    ${where}
+    ORDER BY institution_id, date
+    LIMIT ?`;
+  args.push(limit + 1);
+
+  const { results } = await db
+    .prepare(sql)
+    .bind(...args)
+    .all<{ institution_id: string; date: string; reservation: string }>();
+  const hasNextPage = results.length > limit;
+  const rows = hasNextPage ? results.slice(0, limit) : results;
+  const last = rows.at(-1);
+  return {
+    items: rows.map((row) => ({
+      institution_id: row.institution_id,
+      date: row.date,
+      reservation: parseReservation(row.reservation),
+    })),
+    pageInfo: {
+      hasNextPage,
+      endCursor:
+        hasNextPage && last
+          ? encodeCursor({ institution_id: last.institution_id, date: last.date })
           : null,
     },
   };

--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -4,6 +4,7 @@ import { createLocalJWKSet, type JWTVerifyGetKey } from "jose";
 import { authorizeAdmin } from "./auth/adminAuth.ts";
 import { resolveRole } from "./auth/auth0.ts";
 import {
+  exportReservations,
   getInstitutionDetail,
   listInstitutionReservations,
   listInstitutions,
@@ -51,6 +52,10 @@ const RE_INSTITUTION_RESERVATIONS = new RegExp(
 );
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const PUBLIC_CACHE = "public, max-age=300";
+// 認証必須レスポンスに必ず付ける。Cache-Control 無しの 200 は、エッジキャッシュ側の
+// heuristic freshness で既定 2 時間キャッシュされうる。Authorization ヘッダ付きの
+// リクエストは自動バイパスされる仕様だが、そこに依存せず明示的に落とす。
+const PRIVATE_CACHE = "private, no-store";
 
 // CORS: viewer（別 origin のブラウザ SPA）からの fetch を許可する。
 // 本番/将来の任意サブドメイン(*.shisetsudb.com) と Workers プレビュー(*.trfv-dev.workers.dev)、
@@ -162,7 +167,7 @@ async function handleInstitutionReservations(
     },
     holidays
   );
-  return json(page);
+  return json(page, { headers: { "Cache-Control": PRIVATE_CACHE } });
 }
 
 async function handleSearch(request: Request, url: URL, env: Env): Promise<Response> {
@@ -193,7 +198,7 @@ async function handleSearch(request: Request, url: URL, env: Env): Promise<Respo
     },
     holidays
   );
-  return json(page);
+  return json(page, { headers: { "Cache-Control": PRIVATE_CACHE } });
 }
 
 async function handleScrapeRuns(env: Env): Promise<Response> {
@@ -244,20 +249,11 @@ async function handleAdminHolidays(request: Request, env: Env): Promise<Response
 /** パリティ突合用: 予約を全列 dump（keyset、admin 認可） */
 async function handleAdminExport(request: Request, url: URL, env: Env): Promise<Response> {
   if (!(await authorizeAdmin(request, env, testGithubJwks(env)))) return error(401, "unauthorized");
-  const municipality = parseListParam(url, "municipality");
-  const holidays = await loadHolidays(env.DB);
-  const page = await searchReservations(
-    env.DB,
-    {
-      startDate: "0000-01-01",
-      endDate: "9999-12-31",
-      municipality,
-      limit: parseLimit(url) ?? 1000,
-      cursor: url.searchParams.get("cursor") ?? undefined,
-    },
-    holidays
-  );
-  return json(page);
+  const page = await exportReservations(env.DB, {
+    limit: parseLimit(url),
+    cursor: url.searchParams.get("cursor") ?? undefined,
+  });
+  return json(page, { headers: { "Cache-Control": PRIVATE_CACHE } });
 }
 
 async function handle(request: Request, env: Env): Promise<Response> {

--- a/packages/api/test/adminEndpoints.test.ts
+++ b/packages/api/test/adminEndpoints.test.ts
@@ -167,21 +167,60 @@ describe("PUT /v1/admin/holidays / export", () => {
   });
 
   it("export はページングして全行を dump する", async () => {
-    // search は institutions と JOIN するため、対象施設を入れておく
-    await env.DB.prepare(
-      `INSERT INTO institutions (id, prefecture, municipality) VALUES (?, ?, ?)
-       ON CONFLICT (id) DO NOTHING`
-    )
-      .bind("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "PREFECTURE_TOKYO", "MUNICIPALITY_KOUTOU")
-      .run();
     await putReservations(adminHeaders(), sampleRows(5));
     const res = await SELF.fetch(`${BASE}/v1/admin/reservations/export?limit=2`, {
       headers: adminHeaders(),
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { items: unknown[]; pageInfo: { hasNextPage: boolean } };
+    const body = (await res.json()) as {
+      items: { institution_id: string; date: string; reservation: Record<string, string> }[];
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
     expect(body.items).toHaveLength(2);
     expect(body.pageInfo.hasNextPage).toBe(true);
+    expect(body.items[0]).toEqual({
+      institution_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      date: "2026-08-01",
+      reservation: { RESERVATION_DIVISION_MORNING: "RESERVATION_STATUS_VACANT" },
+    });
+  });
+
+  it("export は institutions に無い予約行も返す（JOIN しない）", async () => {
+    // 施設マスタを一切入れずに dump できることを確認する。JOIN が復活すると
+    // ページごとの全件ソートが戻ってくるため、その回帰を型ではなく挙動で押さえる。
+    await putReservations(adminHeaders(), sampleRows(1));
+    const res = await SELF.fetch(`${BASE}/v1/admin/reservations/export`, {
+      headers: adminHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items).toHaveLength(1);
+  });
+
+  it("export の cursor は PK 順で続きから返す", async () => {
+    await putReservations(adminHeaders(), sampleRows(5));
+    const first = (await (
+      await SELF.fetch(`${BASE}/v1/admin/reservations/export?limit=2`, {
+        headers: adminHeaders(),
+      })
+    ).json()) as { items: { date: string }[]; pageInfo: { endCursor: string | null } };
+    const cursor = first.pageInfo.endCursor as string;
+    const second = (await (
+      await SELF.fetch(`${BASE}/v1/admin/reservations/export?limit=2&cursor=${cursor}`, {
+        headers: adminHeaders(),
+      })
+    ).json()) as { items: { date: string }[]; pageInfo: { hasNextPage: boolean } };
+    expect(first.items.map((r) => r.date)).toEqual(["2026-08-01", "2026-08-02"]);
+    expect(second.items.map((r) => r.date)).toEqual(["2026-08-03", "2026-08-04"]);
+    expect(second.pageInfo.hasNextPage).toBe(true);
+  });
+
+  it("export は認証必須レスポンスとしてキャッシュを禁止する", async () => {
+    await putReservations(adminHeaders(), sampleRows(1));
+    const res = await SELF.fetch(`${BASE}/v1/admin/reservations/export`, {
+      headers: adminHeaders(),
+    });
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
   });
 
   it("export は認可必須（401）", async () => {

--- a/packages/api/test/endpoints.test.ts
+++ b/packages/api/test/endpoints.test.ts
@@ -107,6 +107,22 @@ describe("reservations 認可", () => {
     const res = await SELF.fetch(`${BASE}/v1/institutions/${INSTITUTIONS[0].id}/reservations`);
     expect(res.status).toBe(401);
   });
+
+  it("認証必須の 200 は private, no-store を返す", async () => {
+    // Cache-Control 無しの 200 はエッジ側の heuristic freshness で既定 2 時間
+    // キャッシュされうる。ユーザー単位の応答なので明示的に落とす。
+    const auth = { Authorization: `Bearer ${await userToken()}` };
+    const search = await SELF.fetch(
+      `${BASE}/v1/reservations/search?startDate=2026-08-01&endDate=2026-08-04`,
+      { headers: auth }
+    );
+    const byInstitution = await SELF.fetch(
+      `${BASE}/v1/institutions/${INSTITUTIONS[0].id}/reservations`,
+      { headers: auth }
+    );
+    expect(search.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(byInstitution.headers.get("Cache-Control")).toBe("private, no-store");
+  });
 });
 
 describe("ページングの一連フロー", () => {

--- a/packages/scraper/tools/backend/d1Api.ts
+++ b/packages/scraper/tools/backend/d1Api.ts
@@ -1,4 +1,9 @@
-import type { Institution } from "@shisetsu-viewer/shared";
+import type {
+  Institution,
+  InstitutionSummary,
+  Page,
+  ReservationExportRow,
+} from "@shisetsu-viewer/shared";
 
 import type { ReservationRow } from "./types.ts";
 
@@ -99,35 +104,48 @@ export async function upsertHolidays(rows: { date: string; name: string }[]): Pr
   return res.rowsWritten;
 }
 
-/** パリティ突合用: D1 の予約を全列 dump（keyset 追跡） */
-export async function exportReservations(
-  municipality: string
-): Promise<{ institution_id: string; date: string; reservation: Record<string, string> }[]> {
+/**
+ * パリティ突合用: D1 の予約を全自治体まとめて 1 巡で dump（PK 順 keyset）。
+ * 自治体で分けて取らないのは、サーバ側が institutions と JOIN すると
+ * ページごとに全件ソートが走り、読み取り行数が O(N^2 / page) になるため。
+ * 分類は exportInstitutions() の id → municipality マップで呼び出し側が行う。
+ */
+export async function exportReservations(): Promise<ReservationExportRow[]> {
   const endpoint = requireEnv("D1_API_ENDPOINT");
   const headers = await getAuthHeaders();
-  const all: { institution_id: string; date: string; reservation: Record<string, string> }[] = [];
+  const all: ReservationExportRow[] = [];
   let cursor: string | null = null;
   do {
-    const qs = new URLSearchParams({ municipality, limit: "1000" });
+    const qs = new URLSearchParams({ limit: "1000" });
     if (cursor) qs.set("cursor", cursor);
     const res = await fetch(`${endpoint}/v1/admin/reservations/export?${qs.toString()}`, {
       headers,
     });
     if (!res.ok) throw new Error(`D1 export error ${res.status}: ${await res.text()}`);
-    const page = (await res.json()) as {
-      items: {
-        reservation: { institution_id: string; date: string; reservation: Record<string, string> };
-      }[];
-      pageInfo: { hasNextPage: boolean; endCursor: string | null };
-    };
-    for (const hit of page.items) {
-      all.push({
-        institution_id: hit.reservation.institution_id,
-        date: hit.reservation.date,
-        reservation: hit.reservation.reservation,
-      });
-    }
+    const page = (await res.json()) as Page<ReservationExportRow>;
+    all.push(...page.items);
     cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
   } while (cursor);
   return all;
+}
+
+/**
+ * パリティ突合用: D1 の institution_id → municipality マップ。
+ * Hasura 側のマップを流用しないのは、D1 にしか無い施設の行を取りこぼすと
+ * 「extra」判定が効かなくなり、突合が甘くなるため。
+ */
+export async function exportInstitutions(): Promise<Map<string, string>> {
+  const endpoint = requireEnv("D1_API_ENDPOINT");
+  const map = new Map<string, string>();
+  let cursor: string | null = null;
+  do {
+    const qs = new URLSearchParams({ limit: "100" });
+    if (cursor) qs.set("cursor", cursor);
+    const res = await fetch(`${endpoint}/v1/institutions?${qs.toString()}`);
+    if (!res.ok) throw new Error(`D1 institutions error ${res.status}: ${await res.text()}`);
+    const page = (await res.json()) as Page<InstitutionSummary>;
+    for (const item of page.items) map.set(item.id, item.municipality);
+    cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+  } while (cursor);
+  return map;
 }

--- a/packages/scraper/tools/backend/parity.ts
+++ b/packages/scraper/tools/backend/parity.ts
@@ -6,7 +6,7 @@ import {
 } from "@shisetsu-viewer/shared";
 
 import { graphqlRequest } from "../request.ts";
-import { exportReservations } from "./d1Api.ts";
+import { exportInstitutions, exportReservations } from "./d1Api.ts";
 import {
   compareMunicipality,
   DUAL_WRITE_LIVE_SINCE,
@@ -117,6 +117,24 @@ const liveSince = process.env["PARITY_LIVE_SINCE"] ?? DUAL_WRITE_LIVE_SINCE;
 const window = reservationWindow(new Date());
 const hasuraByMunicipality = await fetchAllHasura(window);
 
+// D1 側も 1 巡だけ取り、自治体別に振り分ける（自治体ごとに取り直すと
+// サーバ側の JOIN + 全件ソートで読み取り行数が桁違いに膨らむ）。
+const d1IdToMunicipality = await exportInstitutions();
+const d1ByMunicipality = new Map<string, Map<string, string>>();
+for (const row of await exportReservations()) {
+  // Hasura と同じ窓に絞る（ISO 日付は辞書順 = 時系列順）。
+  if (row.date < window.from || row.date > window.to) continue;
+  const municipality = d1IdToMunicipality.get(row.institution_id);
+  // 施設マスタに無い予約行は突合対象外（従来のサーバ側 INNER JOIN と同じ扱い）。
+  if (!municipality) continue;
+  let map = d1ByMunicipality.get(municipality);
+  if (!map) {
+    map = new Map<string, string>();
+    d1ByMunicipality.set(municipality, map);
+  }
+  map.set(key(row), canonicalizeReservation(row.reservation));
+}
+
 const reports: MunicipalityReport[] = [];
 
 for (const target of targets) {
@@ -124,13 +142,7 @@ for (const target of targets) {
   const municipality = `MUNICIPALITY_${(m as string).toUpperCase()}`;
 
   const hasura = hasuraByMunicipality.get(municipality) ?? new Map<string, HasuraRow>();
-  const d1Rows = await exportReservations(municipality);
-  // D1 は全期間を返すので Hasura と同じ窓に絞る（ISO 日付は辞書順 = 時系列順）。
-  const d1 = new Map(
-    d1Rows
-      .filter((r) => r.date >= window.from && r.date <= window.to)
-      .map((r) => [key(r), canonicalizeReservation(r.reservation)])
-  );
+  const d1 = d1ByMunicipality.get(municipality) ?? new Map<string, string>();
 
   const report = compareMunicipality(target, hasura, d1, liveSince);
   reports.push(report);

--- a/packages/shared/apiTypes.ts
+++ b/packages/shared/apiTypes.ts
@@ -53,6 +53,17 @@ export interface ReservationSearchHit {
   >;
 }
 
+/**
+ * GET /v1/admin/reservations/export の 1 行。
+ * parity 突合は institution_id / date / reservation しか見ないので、
+ * 導出値（is_holiday・空き 3 フラグ）も institutions の JOIN 結果も持たない。
+ */
+export interface ReservationExportRow {
+  institution_id: string;
+  date: string; // YYYY-MM-DD
+  reservation: Record<string, string>;
+}
+
 /** GET /v1/scrape-runs の 1 行（自治体別最新） */
 export interface ScrapeRun {
   municipality: string; // MUNICIPALITY_*

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -35,6 +35,7 @@ export type {
   InstitutionSummary,
   InstitutionDetail,
   ReservationDto,
+  ReservationExportRow,
   ReservationSearchHit,
   ScrapeRun,
   UpsertReservationsRequest,


### PR DESCRIPTION
## 背景

Cloudflare の利用状況を棚卸ししたところ、**D1 の日次読み取り無料枠（5,000,000 行/日）を毎日 1.1〜6.6 倍超過**していた。超過すると D1 クエリが 00:00 UTC まで拒否され、`shisetsu-api` と `shisetsu-mcp-server` は同一 DB を共有しているので **viewer と MCP が同時に落ちる**。

| 日 | rows read | 枠比 |
|---|---|---|
| 2026-07-18 | 33,251,535 | 665% |
| 2026-07-19 | 24,028,444 | 481% |
| 2026-07-20〜24 | 6.8M〜10.3M | 137〜206% |

## 犯人

7/24 を時間別に割ると、日次 1,024 万行のうち **1,009 万行（98.5%）が 2 時間に集中**していた。

| 時刻 (UTC) | readQueries | rowsRead | rowsWritten | 正体 |
|---|---|---|---|---|
| 10:00 | 176 | 74,422 | 534 | scraper dual-write |
| **11:00** | **1,170** | **5,033,785** | 0 | **parity 突合** |
| 21:00 | 150 | 68,922 | 824 | scraper dual-write |
| **22:00** | **1,187** | **5,059,360** | 15 | **parity 突合** |

`scraper.yml` の cron `23 8,20 * * *` 直後に走る `parity` job（`exportReservations()`）。

## 原因

`/v1/admin/reservations/export` が専用クエリを持たず `searchReservations()` を `startDate: "0000-01-01"` / `endDate: "9999-12-31"` で流用していた。

**(a) `municipality` フィルタが ORDER BY のインデックスを殺す。** 本番 D1 での `EXPLAIN QUERY PLAN`:

```
SEARCH i USING INDEX idx_institutions_list (municipality=?)
SEARCH r USING PRIMARY KEY (institution_id=? AND date>? AND date<?)
USE TEMP B-TREE FOR ORDER BY          ← これ
```

`reservations` は `WITHOUT ROWID` で PK が `(institution_id, date)`、`ORDER BY` は `(date, institution_id)`。municipality で絞ると institutions 駆動の計画になり、**日付順に並べるには候補全件を一時 B-tree でソートするしかない**。keyset カーソルは WHERE 節でしか効かず走査量を減らせないので、コストが O(N² / page) に膨らむ。

**(b) `clampLimit()` の `MAX_LIMIT = 100` が export の `limit=1000` を握り潰していた。** ページ数が 10 倍になる。

### 実測（本番 D1・豊島区 8,928 行、終盤のカーソル位置）

| クエリ形状 | 返却行 | **rows_read** | 所要 |
|---|---|---|---|
| 現行（JOIN + `ORDER BY date,id`） | 101 | **7,073** | 28.5 ms |
| PK 順 keyset（`ORDER BY institution_id,date`） | 1,001 | **1,002** | 7.3 ms |

理論値も一致する。自治体ごとの行数を N として 1 run のコストは Σ(N²/100)：

```
KAWASAKI 15,853² /100 = 2,513,000
EDOGAWA  11,546² /100 = 1,333,000
TOSHIMA   8,928² /100 =   797,000
… 合計 ≈ 5,500,000 行 / readQueries ≈ 1,166
```

実測 5,033,785 行 / 1,170 クエリ。モデルが実測を説明しきっている。

## 変更内容

- `queries.ts` に `exportReservations()` を新設。`ORDER BY institution_id, date` で PK と揃え、**JOIN も municipality フィルタも持たない**。上限は `MAX_EXPORT_LIMIT = 1000`（search 系の 100 は据え置き）。
- `handleAdminExport` を新クエリに差し替え。レスポンスは `Page<ReservationExportRow>`（フラットな `{institution_id, date, reservation}`）。
- 自治体別の分類は `parity.ts` 側で `institution_id → municipality` マップを引いて行う。マップは D1 の `/v1/institutions` から取る（Hasura 側のマップを流用すると、**D1 にしか無い施設の行が落ちて `extra` 判定が効かなくなる**ため）。
- 認証必須レスポンス（`/v1/reservations/search`、`/v1/institutions/:id/reservations`、export）に `Cache-Control: private, no-store` を明示。`Cache-Control` 無しの 200 はエッジ側の heuristic freshness で既定 2 時間キャッシュされうるので、`Authorization` ヘッダによる自動バイパスに依存しない。

## 効果

parity 1 run **5.03M 行 → 約 6 万行**（58,296 行を 59 ページ + institutions 6 ページ）。日次 **10.1M → 0.26M（枠の 5%）**。

## 検証

- `npm test -w @shisetsu-viewer/api` → 89 passed（export の PK 順カーソル・JOIN 非依存・キャッシュヘッダの回帰テストを追加）
- `npm run test:unit -w @shisetsu-viewer/scraper` → 177 passed
- `npm run typecheck:all` / `lint:all` / `format:check:all` → すべて green
- 本番 D1 に対する読み取り専用プローブで rows_read を実測（上表）

## 残課題（別 PR）

- ユーザー向け `/v1/reservations/search` にも同じ O(N²) 経路が残る（municipality フィルタ時）。`reservations.municipality` の非正規化 + `(municipality, date, institution_id)` の複合インデックスで解消できるが、migration が要るので分ける。
- 公開 GET のエッジキャッシュ（`caches.default`）。現状 `Cache-Control: public, max-age=300` はブラウザキャッシュにしか効いていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5bK6XJ7MGRXJaUW2dYPNG