### PR TITLE
perf(api): 公開 GET を Cache API でエッジキャッシュする

### DIFF
--- a/packages/api/src/worker.ts
+++ b/packages/api/src/worker.ts
@@ -52,6 +52,10 @@ const RE_INSTITUTION_RESERVATIONS = new RegExp(
 );
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const PUBLIC_CACHE = "public, max-age=300";
+// 施設マスタは scraper の update:institutions を回したときしか変わらない（週〜月単位）。
+// エッジキャッシュに載る前提なので、scrape-runs より長く持たせる。
+// 代償は upsert 直後の最大 10 分の陳腐化。手動更新の頻度から見て許容する。
+const INSTITUTIONS_CACHE = "public, max-age=600";
 // 認証必須レスポンスに必ず付ける。Cache-Control 無しの 200 は、エッジキャッシュ側の
 // heuristic freshness で既定 2 時間キャッシュされうる。Authorization ヘッダ付きの
 // リクエストは自動バイパスされる仕様だが、そこに依存せず明示的に落とす。
@@ -134,13 +138,13 @@ async function handleListInstitutions(url: URL, env: Env): Promise<Response> {
     limit: parseLimit(url),
     cursor: url.searchParams.get("cursor") ?? undefined,
   });
-  return json(page, { headers: { "Cache-Control": PUBLIC_CACHE } });
+  return json(page, { headers: { "Cache-Control": INSTITUTIONS_CACHE } });
 }
 
 async function handleInstitutionDetail(id: string, env: Env): Promise<Response> {
   const detail = await getInstitutionDetail(env.DB, id);
   if (!detail) return error(404, "institution not found");
-  return json(detail, { headers: { "Cache-Control": PUBLIC_CACHE } });
+  return json(detail, { headers: { "Cache-Control": INSTITUTIONS_CACHE } });
 }
 
 async function handleInstitutionReservations(
@@ -256,7 +260,41 @@ async function handleAdminExport(request: Request, url: URL, env: Env): Promise<
   return json(page, { headers: { "Cache-Control": PRIVATE_CACHE } });
 }
 
-async function handle(request: Request, env: Env): Promise<Response> {
+/**
+ * Cache API によるエッジキャッシュ。
+ *
+ * Worker が生成したレスポンスは自動ではエッジに載らない。`Cache-Control: public` を
+ * 返すだけではブラウザキャッシュにしか効かないので、明示的に put/match する。
+ * ヒット時は D1 を一切引かない（Cache API は read-through ではないので Worker 自体は動く）。
+ *
+ * キーは **メソッドと URL だけの Request** にする。元のリクエストをそのままキーにすると
+ * Origin ヘッダが混ざり、かつ Cloudflare の Cache は任意の `Vary` をほぼ解釈しないため、
+ * ある origin 向けの `Access-Control-Allow-Origin` を別 origin に返す事故が起きる。
+ * CORS ヘッダは fetch 側でリクエストごとに付け直すので、キャッシュ本体には含まれない
+ * （handle() は CORS を付けずに返す。この順序が前提）。
+ *
+ * 何を載せるかはハンドラが返す `Cache-Control: public` が決める。認証必須の応答は
+ * `private, no-store` を返すので、ここに来ても構造的に載らない。
+ */
+async function withEdgeCache(
+  url: URL,
+  ctx: ExecutionContext,
+  produce: () => Promise<Response>
+): Promise<Response> {
+  const cache = caches.default;
+  const key = new Request(url.toString(), { method: "GET" });
+  const hit = await cache.match(key);
+  // キャッシュ由来の Response はヘッダが immutable なので、CORS を後付けできるよう複製する。
+  if (hit) return new Response(hit.body, hit);
+
+  const res = await produce();
+  if (res.status === 200 && res.headers.get("Cache-Control")?.includes("public")) {
+    ctx.waitUntil(cache.put(key, res.clone()));
+  }
+  return res;
+}
+
+async function handle(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   const { pathname } = url;
   try {
@@ -275,15 +313,20 @@ async function handle(request: Request, env: Env): Promise<Response> {
 
     if (request.method === "GET") {
       if (pathname === "/v1/health") return json({ ok: true });
-      if (pathname === "/v1/institutions") return await handleListInstitutions(url, env);
-      if (pathname === "/v1/scrape-runs") return await handleScrapeRuns(env);
+      if (pathname === "/v1/institutions")
+        return await withEdgeCache(url, ctx, () => handleListInstitutions(url, env));
+      if (pathname === "/v1/scrape-runs")
+        return await withEdgeCache(url, ctx, () => handleScrapeRuns(env));
       if (pathname === "/v1/reservations/search") return await handleSearch(request, url, env);
       if (pathname === "/v1/admin/reservations/export")
         return await handleAdminExport(request, url, env);
       const resv = pathname.match(RE_INSTITUTION_RESERVATIONS);
       if (resv) return await handleInstitutionReservations(request, resv[1] as string, url, env);
       const detail = pathname.match(RE_INSTITUTION);
-      if (detail) return await handleInstitutionDetail(detail[1] as string, env);
+      if (detail) {
+        const id = detail[1] as string;
+        return await withEdgeCache(url, ctx, () => handleInstitutionDetail(id, env));
+      }
     }
     if (request.method === "PUT") {
       if (pathname === "/v1/admin/reservations") return await handleAdminReservations(request, env);
@@ -298,7 +341,7 @@ async function handle(request: Request, env: Env): Promise<Response> {
 }
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const origin = allowedOrigin(request.headers.get("Origin"));
 
     // プリフライトはルーティング・レート制限より前に応答する
@@ -315,7 +358,7 @@ export default {
       });
     }
 
-    const res = await handle(request, env);
+    const res = await handle(request, env, ctx);
     if (origin) {
       res.headers.set("Access-Control-Allow-Origin", origin);
       res.headers.append("Vary", "Origin");

--- a/packages/api/test/endpoints.test.ts
+++ b/packages/api/test/endpoints.test.ts
@@ -42,7 +42,7 @@ describe("public endpoints", () => {
   it("GET /v1/institutions → 200 + Cache-Control", async () => {
     const res = await SELF.fetch(`${BASE}/v1/institutions?limit=5`);
     expect(res.status).toBe(200);
-    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=600");
     const body = (await res.json()) as { items: unknown[] };
     expect(body.items.length).toBeGreaterThan(0);
   });
@@ -57,6 +57,47 @@ describe("public endpoints", () => {
   it("不正な ID 形式は 404", async () => {
     const res = await SELF.fetch(`${BASE}/v1/institutions/not-a-uuid`);
     expect(res.status).toBe(404);
+  });
+
+  it("公開 GET はエッジキャッシュから返る（D1 の変更が max-age 内は見えない）", async () => {
+    const url = `${BASE}/v1/institutions/${INSTITUTIONS[1].id}`;
+    const before = (await (await SELF.fetch(url)).json()) as { building: string };
+    expect(before.building).toBe("会館A");
+
+    await env.DB.prepare(`UPDATE institutions SET building = ? WHERE id = ?`)
+      .bind("差し替え後", INSTITUTIONS[1].id)
+      .run();
+
+    const after = (await (await SELF.fetch(url)).json()) as { building: string };
+    expect(after.building).toBe("会館A");
+  });
+
+  it("キャッシュヒットでも CORS は リクエストごとの origin で返る", async () => {
+    // キーから Origin を外している（Cloudflare の Cache は Vary をほぼ解釈しないため）。
+    // CORS は handle() の外で付け直すので、origin が混ざらないことを押さえる。
+    const url = `${BASE}/v1/institutions?limit=1&cors-probe=1`;
+    const first = await SELF.fetch(url, { headers: { Origin: "http://localhost:3000" } });
+    const second = await SELF.fetch(url, { headers: { Origin: "https://app.shisetsudb.com" } });
+    expect(first.headers.get("Access-Control-Allow-Origin")).toBe("http://localhost:3000");
+    expect(second.headers.get("Access-Control-Allow-Origin")).toBe("https://app.shisetsudb.com");
+  });
+
+  it("認証必須の GET はキャッシュされない（D1 の変更が即座に見える）", async () => {
+    const url = `${BASE}/v1/institutions/${INSTITUTIONS[0].id}/reservations?limit=1`;
+    const auth = { Authorization: `Bearer ${await userToken()}` };
+    const before = (await (await SELF.fetch(url, { headers: auth })).json()) as {
+      items: { date: string }[];
+    };
+    expect(before.items.length).toBeGreaterThan(0);
+
+    await env.DB.prepare(`DELETE FROM reservations WHERE institution_id = ?`)
+      .bind(INSTITUTIONS[0].id)
+      .run();
+
+    const after = (await (await SELF.fetch(url, { headers: auth })).json()) as {
+      items: unknown[];
+    };
+    expect(after.items).toHaveLength(0);
   });
 
   it("GET /v1/scrape-runs → 200", async () => {


### PR DESCRIPTION
## 背景

`/v1/institutions`・`/v1/institutions/:id`・`/v1/scrape-runs` は `Cache-Control: public, max-age=300` を返していたが、**Worker が生成したレスポンスは自動ではエッジキャッシュに載らない**。効いていたのはブラウザキャッシュだけで、新規訪問者や別デバイスからのリクエストは毎回 D1 を引いていた。

宣言的な Workers Cache（wrangler の `cache.enabled`）を使う手もあるが、**インストール済み wrangler 4.112.0 の `config-schema.json` に `cache` キーが存在しない**ため、今回は Cache API（`caches.default`）で実装する。

## 変更内容

`withEdgeCache(url, ctx, produce)` を追加し、公開 GET 3 経路を通す。

**何を載せるかはハンドラが決める。** ラッパーは `Cache-Control: public` が付いた 200 だけを `put` する。認証必須の応答は #1661 で `private, no-store` を返すようにしたので、構造的に載らない。ルーティングを増やしても「public を返すかどうか」だけがキャッシュ可否の判断基準になる。

**キーはメソッドと URL だけの `Request` にする。** 元のリクエストをそのままキーにすると:

- `Origin` ヘッダが混ざる。Cloudflare の Cache は任意の `Vary` をほぼ解釈しないため、**ある origin 向けの `Access-Control-Allow-Origin` を別 origin へ返す事故**が起きる。
- `Authorization` 付きリクエストは自動バイパスされるという別仕様にも依存してしまう。

CORS ヘッダは `handle()` の外側（`fetch`）でリクエストごとに付け直しているので、キャッシュ本体には含まれない。**この順序が前提**である点をコメントに残した。

**キャッシュ由来の `Response` はヘッダが immutable** なので、`new Response(hit.body, hit)` で複製してから返す。しないと CORS の後付けで落ちる。

**TTL**：施設マスタを 300 秒 → 600 秒に延長。`update:institutions` は週〜月単位でしか回さないため、upsert 直後に最大 10 分陳腐化する代償は許容する。`scrape-runs` は「最終取得時刻」の表示なので 300 秒のまま。

レートリミッタはキャッシュ参照より **前** に置いたまま。ヒットでも Workers リクエスト枠（Free 100k/日）は消費するため、そこの保護は残す必要がある。

## 効果

- 公開 GET のキャッシュヒットで **D1 read が 0 行**、CPU もほぼ 0。
- 同一 colo の 2 回目以降は D1 の APAC(SIN) 往復が消えるのでレイテンシも下がる。

## 検証

- `npm test -w @shisetsu-viewer/api` → **92 passed**（+3）
  - `公開 GET はエッジキャッシュから返る` — 1 回目の取得後に D1 を書き換え、2 回目が旧値を返すことで HIT を実証
  - `キャッシュヒットでも CORS は リクエストごとの origin で返る`
  - `認証必須の GET はキャッシュされない` — D1 の変更が即座に見えること
- **キャッシュを無効化すると 1 本目が落ちることを確認済み**（`差し替え後` が返る）。テストが通る理由がキャッシュであることの裏取り。
- `typecheck:all` / `lint:all` / `format:check:all` → green

## 補足：残タスクだった「search の O(N²)」について

本 PR とは別に検討していた `/v1/reservations/search` の書き換えは、**本番 D1 で実測した結果、改善にならないと判明したため見送る**。詳細は PR コメントに残す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5bK6XJ7MGRXJaUW2dYPNG