### PR TITLE
ci: api / mcp-server の master マージを自動デプロイにする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+permissions:
+  contents: read
+name: Deploy Workers
+
+# api / mcp-server は Workers Builds に未接続で、`wrangler deploy` を手で叩かないと
+# 本番に届かない。一方 scraper は master を毎回チェックアウトして走るため、
+# クライアントとサーバの契約を同時に変える PR をマージすると「scraper だけ新しい」
+# 状態になる。2026-07-26 に実際にこれで parity が壊れ、D1 の読み取りが
+# 1 日 2,960 万行（無料枠の 5.9 倍）まで膨らんだ。マージ = デプロイに揃えて塞ぐ。
+#
+# viewer は Workers Builds 接続済みなのでここでは扱わない。
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "packages/api/**"
+      - "packages/mcp-server/**"
+      # shared は両 Worker が import する source of truth
+      - "packages/shared/**"
+      - "package-lock.json"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  # 連続マージでデプロイが交差して古い版が後勝ちするのを防ぐ。
+  # cancel-in-progress は付けない（途中で殺すと中途半端な版が残りうる）。
+  group: deploy-workers
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy ${{ matrix.package }}
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    strategy:
+      # 片方が落ちても、もう片方は最後まで走らせる。
+      # 「両方古い」より「どちらが新しいか分かる」方が復旧しやすい。
+      fail-fast: false
+      matrix:
+        package:
+          - api
+          - mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+          node-version-file: .node-version
+      - name: Cache node_modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: node-modules-cache
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-node-modules-24-${{ hashFiles('**/package-lock.json') }}
+      - name: Run npm ci
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci --ignore-scripts
+      # PR の Node CI とは別に、デプロイ直前の tree でもう一度通す。
+      # master への push は必ずしも PR 経由とは限らないため。
+      - name: Test
+        run: npm test -w @shisetsu-viewer/${{ matrix.package }}
+      - name: Deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run deploy -w @shisetsu-viewer/${{ matrix.package }}


### PR DESCRIPTION
## 背景 — 2026-07-26 に実際に起きた事故

`api` と `mcp-server` は Workers Builds に未接続で、`wrangler deploy` を手で叩かないと本番に届かない。一方 **scraper は master を毎回チェックアウトして走る**ため、クライアントとサーバの契約を同時に変える PR をマージすると「**scraper だけ新しい**」状態になる。

#1661（export の PK 順 keyset 化）はまさにその形だった。マージ後:

1. 新クライアントは `municipality` を送らなくなった
2. しかし本番の api は 2026-07-25T01:35Z の版のまま（マージでは何も起きない）
3. 旧サーバはそれを `searchReservations(0000-01-01 〜 9999-12-31, municipality=undefined)` として処理。`MAX_LIMIT=100` でクランプ
4. **1 ページで 35,739 行読んで 3 行返す**（本番 D1 実測）。583 ページで約 2,000 万行
5. D1 の日次読み取りが **29,642,557 行**（無料枠 5M の **5.9 倍**）

```
2026-07-25T21:00:00Z rq=880  rr=5,441,697
2026-07-25T22:00:00Z rq=1245 rr=18,749,989
```

6. export に **17 分**かかるため、実行開始時に 1 度取得した GitHub OIDC トークンが途中で失効し、parity が `D1 export error 401` で失敗。リトライも 30 分のジョブ制限で cancel

本番の api は手動デプロイ済み（active deployment `80c138a7` / version `10c8f338`、#1661 + #1662 を含む）。この PR は**同じ事故を二度起こさないための恒久対策**。

## 変更内容

`.github/workflows/deploy.yml` を追加し、master への push を `wrangler deploy` に繋ぐ。**マージ = デプロイ**に揃える。

| 設計 | 理由 |
|---|---|
| 対象は `api` と `mcp-server` の 2 つ | viewer は Workers Builds 接続済み（PR チェックに出ている）ので対象外 |
| `paths` に `packages/shared/**` を含める | 両 Worker が import する source of truth。ここだけ変わってデプロイされないと同じ事故になる |
| matrix `fail-fast: false` | 片方が落ちても、もう片方は最後まで走らせる。「両方古い」より「どちらが新しいか分かる」方が復旧しやすい |
| `concurrency` に `cancel-in-progress` を付けない | 途中で殺すと中途半端な版が残りうる。連続マージは直列化するだけでよい |
| デプロイ直前にもう一度テストを通す | master への push が必ずしも PR 経由とは限らない |
| `workflow_dispatch` あり | 手動で本番に揃え直せる逃げ道を残す |

## マージ前に必要な設定

**未登録なので、このままマージすると deploy ジョブが落ちます。**

```sh
# Workers Scripts:Edit 権限の API トークンを Cloudflare ダッシュボードで発行してから
gh secret set CLOUDFLARE_API_TOKEN
gh variable set CLOUDFLARE_ACCOUNT_ID --body '<account id>'
```

リポジトリが public なのでアカウント ID はワークフローに直書きせず variable 参照にしている。

## 検証

- `actionlint .github/workflows/deploy.yml` → OK
- `npm test -w @shisetsu-viewer/api` → 92 passed
- `npm test -w @shisetsu-viewer/mcp-server` → 24 passed

## 残る穴（この PR では塞いでいない）

**D1 マイグレーション**は依然として手動（`npm run migrate:remote`）。マイグレーションを含む PR をマージすると、Worker だけ新しくなってスキーマが古いという、今回と同じ形の破綻が起きうる。自動適用は不可逆操作を CI に載せることになるので、別途相談したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5bK6XJ7MGRXJaUW2dYPNG