### PR TITLE
refactor(ci): 国内 proxy の経路を Tailscale から Cloudflare Tunnel へ移す

### DIFF
--- a/.github/actions/scrape/action.yml
+++ b/.github/actions/scrape/action.yml
@@ -26,8 +26,8 @@ inputs:
     description: "Phase label for failure artifact namespacing (scrape or retry)"
     required: false
     default: "scrape"
-  jpProxyUrl:
-    description: "JP proxy URL (repository variable JP_PROXY_URL)。scraperViaJpProxy の自治体で必須"
+  jpProxyHostname:
+    description: "国内 proxy の Access ホスト名 (repository variable JP_PROXY_HOSTNAME)。scraperViaJpProxy の自治体で必須"
     required: false
     default: ""
 
@@ -59,18 +59,59 @@ runs:
       working-directory: packages/scraper
       run: |
         VIA=$(node scripts/viaJpProxy.ts "${{ inputs.municipality }}")
-        if [ "${VIA}" = "true" ] && [ -z "${{ inputs.jpProxyUrl }}" ]; then
-          echo "::error::${{ inputs.municipality }} は国内 proxy が必要ですが jpProxyUrl が空です（repository variable JP_PROXY_URL を確認）"
+        if [ "${VIA}" = "true" ] && [ -z "${{ inputs.jpProxyHostname }}" ]; then
+          echo "::error::${{ inputs.municipality }} は国内 proxy が必要ですが jpProxyHostname が空です（repository variable JP_PROXY_HOSTNAME を確認）"
           exit 1
         fi
         echo "viaJpProxy=${VIA}" >> "$GITHUB_OUTPUT"
-    - name: Connect to Tailscale
+    - name: Open JP proxy tunnel
       if: steps.jp-proxy.outputs.viaJpProxy == 'true'
-      uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888 # v4.1.3
-      with:
-        oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
-        oauth-secret: ${{ env.TS_OAUTH_SECRET }}
-        tags: tag:ci
+      shell: bash
+      env:
+        # cloudflared のリリースは checksum マニフェストを持たないため、タグ固定までしかできない
+        CLOUDFLARED_VERSION: "2026.7.3"
+        JP_PROXY_HOSTNAME: ${{ inputs.jpProxyHostname }}
+        TUNNEL_SERVICE_TOKEN_ID: ${{ env.CF_ACCESS_CLIENT_ID }}
+        TUNNEL_SERVICE_TOKEN_SECRET: ${{ env.CF_ACCESS_CLIENT_SECRET }}
+      run: |
+        set -euo pipefail
+        if [ -z "${TUNNEL_SERVICE_TOKEN_ID}" ] || [ -z "${TUNNEL_SERVICE_TOKEN_SECRET}" ]; then
+          echo "::error::国内 proxy に必要な secrets CF_ACCESS_CLIENT_ID / CF_ACCESS_CLIENT_SECRET が未設定です"
+          exit 1
+        fi
+
+        curl -fsSL --retry 3 -o "${RUNNER_TEMP}/cloudflared" \
+          "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64"
+        chmod +x "${RUNNER_TEMP}/cloudflared"
+
+        # preflight。正常時は 200。失敗はここで落として Playwright まで持ち越さない
+        # （持ち越すと ERR_CONNECTION_RESET になり、原因が経路か認証かサイトか判別できない）
+        CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
+          -H "CF-Access-Client-Id: ${TUNNEL_SERVICE_TOKEN_ID}" \
+          -H "CF-Access-Client-Secret: ${TUNNEL_SERVICE_TOKEN_SECRET}" \
+          "https://${JP_PROXY_HOSTNAME}/" || true)
+        echo "preflight: HTTP ${CODE}"
+        if [ "${CODE}" != "200" ]; then
+          echo "::error::国内 proxy の経路が異常です（HTTP ${CODE}）。530 = Mac 側コネクタ不在（Mac 停止・cloudflared 停止）、403 = service token かポリシーの不一致"
+          exit 1
+        fi
+
+        "${RUNNER_TEMP}/cloudflared" access tcp \
+          --hostname "${JP_PROXY_HOSTNAME}" \
+          --url 127.0.0.1:8888 \
+          --log-level info \
+          > "${RUNNER_TEMP}/cloudflared-access.log" 2>&1 &
+
+        for _ in $(seq 1 30); do
+          if timeout 1 bash -c '</dev/tcp/127.0.0.1/8888' 2>/dev/null; then
+            echo "cloudflared access が 127.0.0.1:8888 で待ち受けています"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::cloudflared access の listener が 30 秒以内に起動しませんでした"
+        cat "${RUNNER_TEMP}/cloudflared-access.log"
+        exit 1
     - name: Run Playwright tests
       shell: bash
       working-directory: packages/scraper
@@ -79,13 +120,17 @@ runs:
         TZ: Asia/Tokyo
         # dispatch で自治体を指定した場合は registry の CI 除外（scraperCiExcluded）を解除する
         SCRAPER_FORCE_INCLUDE: ${{ inputs.municipality }}
-        SCRAPER_PROXY: ${{ steps.jp-proxy.outputs.viaJpProxy == 'true' && inputs.jpProxyUrl || '' }}
+        SCRAPER_PROXY: ${{ steps.jp-proxy.outputs.viaJpProxy == 'true' && 'http://127.0.0.1:8888' || '' }}
       run: |
         if [ "${{ inputs.debug }}" == "true" ]; then
           DEBUG=pw:api npx playwright test ${{ inputs.municipality }} --shard=${{ inputs.shardIndex }}/${{ inputs.shardTotal }}
         else
           npx playwright test ${{ inputs.municipality }} --shard=${{ inputs.shardIndex }}/${{ inputs.shardTotal }}
         fi
+    - name: Dump JP proxy tunnel log
+      if: ${{ failure() && steps.jp-proxy.outputs.viaJpProxy == 'true' }}
+      shell: bash
+      run: cat "${RUNNER_TEMP}/cloudflared-access.log" || true
     - name: Check test results
       id: check-results
       shell: bash

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -121,8 +121,8 @@ jobs:
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
           # dual-write のキルスイッチ: repository variable が未設定なら空 → scraper は D1 書き込みをスキップ
           D1_API_ENDPOINT: ${{ vars.D1_API_ENDPOINT }}
-          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         with:
           municipality: ${{ matrix.municipality }}
           shardIndex: ${{ matrix.shardIndex }}
@@ -130,7 +130,7 @@ jobs:
           nodeModulesCacheKey: ${{ needs.prepare.outputs.nodeModulesCacheKey }}
           playwrightCacheKey: ${{ needs.prepare.outputs.playwrightCacheKey }}
           debug: "false"
-          jpProxyUrl: ${{ vars.JP_PROXY_URL }}
+          jpProxyHostname: ${{ vars.JP_PROXY_HOSTNAME }}
 
   prepare_retry:
     runs-on: ubuntu-latest
@@ -187,8 +187,8 @@ jobs:
           M2M_TOKEN: ${{ secrets.M2M_TOKEN }}
           # dual-write のキルスイッチ: repository variable が未設定なら空 → scraper は D1 書き込みをスキップ
           D1_API_ENDPOINT: ${{ vars.D1_API_ENDPOINT }}
-          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         with:
           municipality: ${{ matrix.municipality }}
           shardIndex: ${{ matrix.shardIndex }}
@@ -197,7 +197,7 @@ jobs:
           playwrightCacheKey: ${{ needs.prepare.outputs.playwrightCacheKey }}
           debug: "true"
           phase: "retry"
-          jpProxyUrl: ${{ vars.JP_PROXY_URL }}
+          jpProxyHostname: ${{ vars.JP_PROXY_HOSTNAME }}
 
   collect_failures:
     name: Collect structural failures

--- a/docs/superpowers/specs/2026-07-19-sumida-jp-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-19-sumida-jp-proxy-design.md
@@ -113,3 +113,41 @@ proxy 経由になることで 1 リクエストあたりの遅延は増える�
 - transient 分類の失敗が tracker Issue に載らない問題の一般的な改善（sumida 以外にも関わるため別課題とする）
 - Oracle Cloud（ap-tokyo-1）からの到達性実測と、Mac 常時稼働をやめる場合の VM 移行
 - 杉並区（Cloudflare Turnstile）のような、IP 以外の要因で CI 除外されている自治体への適用
+
+## 追記（2026-07-31）: トランスポートを Cloudflare Tunnel へ移行
+
+本文の設計のうち、**CI ランナーから Mac の 8888 番へ到達する経路**だけを Tailscale から
+Cloudflare Tunnel に差し替えた。tinyproxy が住宅 IP から出す部分、registry の
+`scraperViaJpProxy` を単一ソースとする判定、`SCRAPER_PROXY` を playwright.config が
+`use.proxy` に適用する部分は、いずれも変更していない。
+
+```
+GH Actions runner
+  └─ cloudflared access tcp（127.0.0.1:8888 で待受）
+       └─ Cloudflare edge（Access の Service Auth ポリシー + service token で認可）
+            └─ Mac の cloudflared（LaunchAgent 常駐）
+                 └─ tinyproxy 127.0.0.1:8888 → 自宅 ISP → 対象サイト
+```
+
+移行の理由は、依存先を Cloudflare（D1・Workers・ゾーン）に集約し、Tailscale の
+アカウント・OAuth client・ACL の管理を畳むことである。副次的に 2 点が改善した。
+
+- CI ランナーが tailnet に ephemeral join しなくなった。Access の service token で
+  「1 つの TCP アプリケーションへの認可」に境界が狭まる
+- `JP_PROXY_URL` に Tailscale IP をハードコードする必要がなくなった。CI 側の
+  proxy 宛先は常に `http://127.0.0.1:8888` になる
+
+一方で **Mac 常時稼働への依存は解消していない**。これはトランスポートの問題ではなく、
+住宅 IP を出口にする構成そのものの性質である。解消したい場合は、スコープ外に挙げた
+Oracle Cloud（ap-tokyo-1）の到達性実測から着手することになる。
+
+代わりに、切り分けの悪化を防ぐ preflight を scrape アクションに入れた。
+Tailscale 版では Mac 停止も CI 側 proxy の不調も等しく Playwright の
+`ERR_PROXY_CONNECTION_FAILED`（transient 分類）に潰れていたが、
+`cloudflared access tcp` を起動する前に service token 付きで Access ホスト名を叩き、
+`HTTP 530`（Cloudflare error 1033 = Mac 側コネクタ不在）と `HTTP 403`（token 失効・
+ポリシー不整合）を、それぞれ固有のエラーメッセージで即座に落とすようにしてある。
+
+CI 側の cloudflared は GitHub リリースからバージョンタグ固定で取得する。
+cloudflared のリリースには checksum マニフェストが無いため、actions の SHA pin に
+相当する固定はタグまでしかできない。

--- a/packages/scraper/CLAUDE.md
+++ b/packages/scraper/CLAUDE.md
@@ -39,7 +39,7 @@ Playwright-based scrapers for municipal reservation systems; results are uploade
 - testMatch は `**/index.test.ts`。非 index の `*.test.ts` は `node --test` 用ユニットテスト（`npm run test:unit`）で、Playwright には拾われない。
 - Workers: 4 local / 1 CI。`WORKERS` / `SLOW_MO` env で上書き。
 - CI 除外は registry 駆動: shared `registry.ts` の `scraperCiExcluded` から `testIgnore` を構築（`SCRAPER_FORCE_INCLUDE` で個別上書き）。
-- 国内 proxy: registry の `scraperViaJpProxy` の自治体は、CI で Tailscale + Mac の tinyproxy 経由（`SCRAPER_PROXY`）。セットアップは `tools/jp-proxy/README.md`。
+- 国内 proxy: registry の `scraperViaJpProxy` の自治体は、CI で Cloudflare Tunnel + Mac の tinyproxy 経由（`SCRAPER_PROXY=http://127.0.0.1:8888` 固定）。セットアップと故障の切り分けは `tools/jp-proxy/README.md`。
 
 ## Adding a New Municipality
 

--- a/packages/scraper/tools/jp-proxy/README.md
+++ b/packages/scraper/tools/jp-proxy/README.md
@@ -1,30 +1,40 @@
-# 国内 proxy（Tailscale + tinyproxy）のセットアップ
+# 国内 proxy（Cloudflare Tunnel + tinyproxy）のセットアップ
 
 tokyo-sumida はサイト側が GitHub Actions からの接続を L4 で遮断しているため、
-CI は Tailscale で Mac の tinyproxy に接続し、住宅 IP からスクレイプする。
+CI は Cloudflare Tunnel で Mac の tinyproxy に接続し、住宅 IP からスクレイプする。
 設計: `docs/superpowers/specs/2026-07-19-sumida-jp-proxy-design.md`
+
+Cloudflare が担うのは「CI ランナーから Mac の 8888 番へ到達する経路」だけである。
+住宅 IP から出るという肝心の性質は、従来どおり Mac の tinyproxy と自宅 ISP が担う。
+
+```
+GH Actions runner
+  └─ cloudflared access tcp（ローカル 127.0.0.1:8888 で待受）
+       └─ Cloudflare edge（Access の service token で認可）
+            └─ Mac の cloudflared
+                 └─ tinyproxy 127.0.0.1:8888
+                      └─ 自宅 ISP → yoyaku03.city.sumida.lg.jp
+```
 
 ## Mac 側
 
-1. Tailscale をインストールしてログインする（App 版または `brew install tailscale`）
-2. Tailscale の IPv4 を確認する: `tailscale ip -4`（以下 `<TS_IP>`）
-3. tinyproxy を入れて設定する:
+1. tinyproxy を入れて設定する:
 
    ```bash
    brew install tinyproxy
    ```
 
    `$(brew --prefix)/etc/tinyproxy/tinyproxy.conf` を次の内容にする
-   （Tailscale IF にのみ bind し、tailnet からのみ許可。宛先も対象サイトの 443 番に限定する）:
+   （loopback にのみ bind する。外部からの到達は cloudflared だけが担う）:
 
    ```
    Port 8888
-   Listen <TS_IP>
+   Listen 127.0.0.1
    Timeout 600
    MaxClients 20
-   Allow 100.64.0.0/10
-   # 宛先制限: 万一 tailnet 参加まで突破されても、この proxy は
-   # 対象サイトへの閲覧以外（localhost / LAN への CONNECT 含む）に使えない
+   Allow 127.0.0.1
+   # 宛先制限: 万一 Access を突破されても、この proxy は対象サイトへの閲覧以外
+   # （localhost / LAN への CONNECT 含む）に使えない
    FilterDefaultDeny Yes
    Filter "/opt/homebrew/etc/tinyproxy/filter"
    ConnectPort 443
@@ -40,50 +50,93 @@ CI は Tailscale で Mac の tinyproxy に接続し、住宅 IP からスクレ�
 
    proxy 経由の自治体を増やすときは、この filter に 1 行追加する。
 
-4. 常駐させる: `brew services start tinyproxy`
-5. 動作確認（Mac 自身から Tailscale IF 経由で）:
+2. 常駐させる: `brew services start tinyproxy`
+3. 動作確認（Mac 自身から）:
 
    ```bash
-   curl -x http://<TS_IP>:8888 -s -o /dev/null -w "%{http_code}\n" \
+   curl -x http://127.0.0.1:8888 -s -o /dev/null -w "%{http_code}\n" \
      https://yoyaku03.city.sumida.lg.jp/user/Home
    ```
 
    → `200`
 
-## Tailscale 管理画面
+4. cloudflared を入れる: `brew install cloudflared`
+5. Cloudflare 側（次節）で Tunnel を作ってトークンを取得したら、コネクタを常駐させる:
 
-1. **タグ定義とアクセス制御**（Access Controls。現行の管理画面は grants 構文）:
-
-   ```jsonc
-   "tagOwners": { "tag:ci": ["autogroup:admin"] },
-   "grants": [
-     // 自分のデバイス同士は従来どおり全許可（タグ付きノードは含まれない）
-     {"src": ["autogroup:member"], "dst": ["*"], "ip": ["*"]},
-     // CI ノードは Mac の proxy ポートにのみ到達できる
-     {"src": ["tag:ci"], "dst": ["<TS_IP>"], "ip": ["tcp:8888"]},
-   ],
+   ```bash
+   sudo cloudflared service install <トークン>
    ```
 
-   既定の `{"src": ["*"], "dst": ["*"], "ip": ["*"]}` は tag:ci にも全アクセスを許すため、
-   `autogroup:member` に絞り替える。
+   macOS では `/Library/LaunchDaemons/com.cloudflare.cloudflared.plist` に
+   root の LaunchDaemon として登録され、トークンは
+   `/Library/Application Support/com.cloudflare.cloudflared/token` に置かれる。
 
-2. **OAuth client**（Settings → Trust credentials → Credential → OAuth）:
-   scope は Auth Keys の Write、タグは `tag:ci` を割り当てる。
-   Client Secret は生成時にしか表示されないため、その場で控える
+   **常駐の強さが tinyproxy と非対称である点に注意する。** cloudflared は
+   LaunchDaemon なのでログインセッションに依存しないが、tinyproxy は
+   brew services の LaunchAgent なのでログアウトすると止まる。この状態では
+   Tunnel は healthy のままなので CI の preflight は通過し、Playwright だけが
+   `ERR_PROXY_CONNECTION_FAILED` で落ちる。
+
+   状態確認: `sudo launchctl list | grep cloudflared`、`lsof -nP -iTCP:8888 -sTCP:LISTEN`
+
+## Cloudflare 側
+
+ゾーン `shisetsudb.com` と Zero Trust 組織は既存のものを使う。Zero Trust の
+無料プラン（50 seats）の範囲に収まり、追加費用は発生しない。
+
+1. **Tunnel を作る**（ダッシュボード → Networking → Tunnels）:
+   - 種別は `cloudflared`、名前は `jp-proxy`
+   - 表示されるインストールコマンドのトークンを控え、Mac 側の手順 5 で使う
+
+2. **ルートを追加する**（作った Tunnel → ルート タブ → ルートを追加 → **公開アプリケーション**）:
+   - Subdomain `jp-proxy` / Domain `shisetsudb.com`
+   - Service URL に **`tcp://127.0.0.1:8888`**
+
+   Service URL のスキームは `http://` ではなく **`tcp://`** である。HTTP にすると
+   cloudflared がリクエストを HTTP として解釈して転送するため、CI 側の
+   `cloudflared access tcp` が張る生の TCP ストリーム（tinyproxy への CONNECT）が壊れる。
+
+   DNS の CNAME（`jp-proxy` → `<Tunnel UUID>.cfargotunnel.com`）は自動で作られる。
+
+3. **Access アプリケーションを作る**（Zero Trust → Access → Applications）:
+   - 種別 Self-hosted、ドメイン `jp-proxy.shisetsudb.com`
+   - これを付けないと、ホスト名を知っている誰でも `cloudflared access tcp` で
+     この proxy を使えてしまう。宛先は tinyproxy の filter で sumida に限定されて
+     いるとはいえ、住宅 IP を第三者に貸すことになる
+
+4. **service token を作る**（Zero Trust → Access controls → Service credentials → Service Tokens）:
+   - 名前は `github-actions-scraper` など
+   - **Client Secret は生成時にしか表示されない**ので、その場で控える
+   - 有効期限（Service Token Duration）を設定した場合、失効時は CI の preflight が
+     `HTTP 403` で落ちる
+
+5. **手順 3 のアプリに Service Auth ポリシーを付ける**:
+   - Action は **Service Auth**。Allow にすると ID プロバイダのログインを要求され、
+     CI からは通らない
+   - Include に手順 4 の service token を指定する
 
 ## GitHub 側
 
 ```bash
-gh secret set TS_OAUTH_CLIENT_ID --repo trfv/shisetsu-viewer
-gh secret set TS_OAUTH_SECRET --repo trfv/shisetsu-viewer
-gh variable set JP_PROXY_URL --repo trfv/shisetsu-viewer --body "http://<TS_IP>:8888"
+gh secret set CF_ACCESS_CLIENT_ID --repo trfv/shisetsu-viewer
+gh secret set CF_ACCESS_CLIENT_SECRET --repo trfv/shisetsu-viewer
+gh variable set JP_PROXY_HOSTNAME --repo trfv/shisetsu-viewer --body "jp-proxy.shisetsudb.com"
 ```
 
-`JP_PROXY_URL` は MagicDNS 名ではなく Tailscale IP を使う
-（ephemeral ノードの DNS 解決に依存しないため）。
+`JP_PROXY_HOSTNAME` はスキームもポートも付けないホスト名だけを入れる。
+CI 側の proxy URL（`SCRAPER_PROXY`）は `http://127.0.0.1:8888` 固定であり、
+リポジトリ変数にはしない。
 
-## 運用
+## 故障の切り分け
 
-- Mac は常時稼働・AC 接続とする
-- proxy 停止時は sumida のジョブが transient 失敗し、retry 込みで落ちると run が赤くなる
-- 停止・再開: `brew services stop|start tinyproxy`
+scrape ジョブの `Open JP proxy tunnel` ステップが、経路のどこが切れているかを
+Playwright に到達する前に確定させる。
+
+preflight は正常時に `HTTP 200` を返す。それ以外はステップがその場で落ちる。
+
+| 症状 | 原因 | 対処 |
+| --- | --- | --- |
+| `HTTP 530`（Cloudflare error 1033） | Mac が停止・スリープ、または cloudflared が落ちている | Mac を起動し `sudo launchctl list \| grep cloudflared` を確認 |
+| `HTTP 403` | service token の失効・値の誤り、または Service Auth ポリシー不整合 | Client ID が Access API の値と一致しているか確認し、Secret を再設定する |
+| listener が 30 秒以内に起動しない | CI 側 cloudflared の起動失敗 | 同ジョブの `Dump JP proxy tunnel log` ステップの出力を見る |
+| Playwright が `ERR_PROXY_CONNECTION_FAILED` | preflight は通ったが tinyproxy が落ちている、または宛先が filter で拒否された | Mac で `brew services list` と `/opt/homebrew/etc/tinyproxy/filter` を確認 |

--- a/packages/shared/registry.ts
+++ b/packages/shared/registry.ts
@@ -14,8 +14,8 @@ export interface MunicipalityConfig {
   readonly scraperCiExcluded?: boolean;
   /**
    * true = サイトが GitHub Actions からの接続を遮断しているため、CI では
-   * 国内 proxy 経由でスクレイプする。scrape アクションが Tailscale join と
-   * SCRAPER_PROXY 設定を行う（判定は scripts/viaJpProxy.ts）。
+   * 国内 proxy 経由でスクレイプする。scrape アクションが Cloudflare Tunnel の
+   * 中継起動と SCRAPER_PROXY 設定を行う（判定は scripts/viaJpProxy.ts）。
    */
   readonly scraperViaJpProxy?: boolean;
   /** サイトのメンテナンス時間帯 [開始時, 終了時)（JST の時、半開区間） */


### PR DESCRIPTION
CI ランナーから Mac の tinyproxy へ到達する経路だけを Tailscale から Cloudflare Tunnel に差し替える。依存先を Cloudflare（D1・Workers・ゾーン）に集約し、Tailscale のアカウント・OAuth client・ACL の管理を畳むのが目的。

## 変えていないもの

住宅 IP から出すという肝心の性質は tinyproxy と自宅 ISP が担っており、そこは無変更。registry の `scraperViaJpProxy` を単一ソースとする判定、`SCRAPER_PROXY` を `playwright.config.ts` が `use.proxy` に適用する部分も無変更。

```
GH Actions runner
  └─ cloudflared access tcp（127.0.0.1:8888 で待受）
       └─ Cloudflare edge（Access の Service Auth ポリシー + service token で認可）
            └─ Mac の cloudflared（LaunchDaemon 常駐）
                 └─ tinyproxy 127.0.0.1:8888 → 自宅 ISP → 対象サイト
```

## 改善点

- CI ランナーが tailnet に ephemeral join しなくなる。信頼境界が「1 つの TCP アプリケーションへの認可」に狭まる
- `JP_PROXY_URL` への Tailscale IP ハードコードが不要になる。CI 側の proxy 宛先は `http://127.0.0.1:8888` 固定
- **preflight を追加**。`cloudflared access tcp` の起動前に Access ホスト名を service token 付きで叩き、`HTTP 200` 以外で落とす。実測で正常時 200 / コネクタ不在 530 / 認証不一致 403 に分かれることを確認済み。Tailscale 版ではいずれも Playwright の `ERR_PROXY_CONNECTION_FAILED`（transient 分類）に潰れていた

## 解消していないもの

**Mac 常時稼働への依存はそのまま**。これはトランスポートの問題ではなく、住宅 IP を出口にする構成そのものの性質。解消するなら spec のスコープ外に挙げた Oracle Cloud ap-tokyo-1 の到達性実測が入口になる。

## 既知の妥協

CI 側の cloudflared は GitHub リリースからバージョンタグ（`2026.7.3`）固定で取得する。cloudflared のリリースには checksum マニフェストが存在しないため、actions の SHA pin に相当する固定はタグまでしかできない。

## 実環境のセットアップ（完了）

- [x] Cloudflare: Tunnel `jp-proxy`（healthy）+ ルート `jp-proxy.shisetsudb.com` → `tcp://127.0.0.1:8888`、DNS CNAME 自動生成
- [x] Cloudflare: Access アプリ（Self-hosted）+ Service Auth ポリシー + service token `github-actions-scraper`
- [x] Mac: `cloudflared` を LaunchDaemon で常駐（`/Library/LaunchDaemons/com.cloudflare.cloudflared.plist`）
- [x] Mac: tinyproxy を `Listen 127.0.0.1` に変更（宛先 filter と `ConnectPort 443` は据え置き）
- [x] GitHub: secrets `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET`、variable `JP_PROXY_HOSTNAME`

## 検証結果

| 検証 | run | 結果 |
| --- | --- | --- |
| 経路単体（Access 追加前、住宅 IP から） | ローカル | 4 passed / 48.7s |
| Access のネガティブ検証（トークン無し） | — | `HTTP 403`（tinyproxy に到達しない） |
| 正常系 sumida（最終コミット `4d6e3ca`） | 30640801720 | ✅ preflight 200 → 4 passed (4.5m)、hasura 4410 rows、D1 upsert 成功、retry skipped。ジョブ全体 **5 分 22 秒**（現行 Tailscale 経由 6.1 分より速い） |
| 対照 tokyo-chuo（最終コミット `4d6e3ca`） | 30640815577 | ✅ `Open JP proxy tunnel` skip・`SCRAPER_PROXY` 空・2 シャードとも success |

異常系（Mac の cloudflared 停止で preflight が 530）は未実施。

## マージ後にやること

Tailscale 側の後片付け。

- GitHub: secrets `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET`、variable `JP_PROXY_URL` を削除
- Tailscale: OAuth client と `tag:ci` の ACL を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)
